### PR TITLE
Rewrite RCE fix and 23400 fix

### DIFF
--- a/source/patches/patchcode.h
+++ b/source/patches/patchcode.h
@@ -36,8 +36,7 @@ void langpatcher(void *addr, u32 len, u8 languageChoice);
 void vidolpatcher(void *addr, u32 len);
 void patchdebug(void *addr, u32 len);
 int LoadGameConfig(const char *CheatFilepath);
-int ocarina_patch_mkw(u8 *gameid);
-int ocarina_patch_games(u8 *gameid);
+int ocarina_patch(u8 *gameid);
 int ocarina_load_code(const char *CheatFilepath, u8 *gameid);
 
 #ifdef __cplusplus


### PR DESCRIPTION
I just noticed that you added Seeky's RCE protection patch for MKWii and Invoxi's 23400 patch for a couple games and I just wanted to clean up its implementation a bit. 

With this PR, two things about these patches change
- using the RCE protection and the 23400 patch no longer requires the Gecko handler to be enabled, the patches are just directly applied to the game if needed, and
- the RCE patch is not applied to MKWii if the game has already been Wiimmfi-patched before, either with the USB Loader itself or with an external ISO / WBFS patcher. 

Unfortunately I was unable to compile this fork of the USB Loader due to a missing `sys/uio.h` from somewhere in the libwolfssl code, so maybe someone else can check if this code still works correctly. Otherwise that'll have to wait until I can figure out how to fix this. 