### PR TITLE
On non-MS operating systems, file names are usually case-sensitive.

### DIFF
--- a/source/network/networkops.cpp
+++ b/source/network/networkops.cpp
@@ -11,7 +11,7 @@
 #include "networkops.h"
 #include "https.h"
 #include "update.h"
-#include "settings/ProxySettings.h"
+#include "settings/proxysettings.h"
 
 #define PORT 4299
 


### PR DESCRIPTION
On non-MS operating systems, file names are usually case-sensitive.

Compile on Linux with
```
sudo docker run --rm -v $(pwd):/src:Z -w /src -u $(id -u ${USER}):$(id -g ${USER}) -it devkitpro/devkitppc /usr/bin/make
```