### PR TITLE
Add Github CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,63 @@
+name: Build binaries
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache
+        id: cache-1
+        uses: actions/cache@v2
+        with:
+          path: cache
+          key: ${{ runner.os }}-cache-1
+
+      - name: Download devkitPPC r38, libogc 2.1.0, bin2s and elf2dol
+        if: steps.cache-1.outputs.cache-hit != 'true'
+        # general-tools is needed for bin2s and gamecube-tools is needed for elf2dol
+        run: | 
+          mkdir cache && cd cache
+          wget "https://wii.leseratte10.de/devkitPro/file.php/devkitPPC-r38-1-linux_x86_64.pkg.tar.xz"
+          wget "https://wii.leseratte10.de/devkitPro/file.php/devkitppc-rules-1.1.0-1-any.pkg.tar.xz"
+          wget "https://wii.leseratte10.de/devkitPro/file.php/libogc-2.1.0-1-any.pkg.tar.xz"
+          wget "https://wii.leseratte10.de/devkitPro/file.php/general-tools-1.2.0-1-linux.pkg.tar.xz"
+          wget "https://wii.leseratte10.de/devkitPro/file.php/gamecube-tools-1.0.2-1-linux.pkg.tar.xz"
+          cd ..
+
+      - name: Verify checksums for the downloaded files
+        run: |
+          sha256sum -c <<EOF
+          b8775c66e7500182a5f93335140d575a65ca2beb7110dfba16bf1eaf1d6fe13a  cache/devkitPPC-r38-1-linux_x86_64.pkg.tar.xz
+          5cbb617bee3d53a6857427af9168694e21095ae3223819df62aaeaf52750d772  cache/devkitppc-rules-1.1.0-1-any.pkg.tar.xz
+          6ac68676e33fd53d8b716ea6c7247b0e465eff7f7a3cbb0e3093310615a48863  cache/gamecube-tools-1.0.2-1-linux.pkg.tar.xz
+          69edef800f01ff66dc5ed4d173cb3ac07e5336fbb926369eaa3c38163775c350  cache/general-tools-1.2.0-1-linux.pkg.tar.xz
+          220871bfc45abcab612e020a00e6c8f19f51eb1be2d3c7d23f42cb10497ba786  cache/libogc-2.1.0-1-any.pkg.tar.xz
+          EOF
+
+
+      - name: Extract everything
+        # general-tools is needed for bin2s and gamecube-tools is needed for elf2dol
+        run: | 
+          tar -xf cache/devkitPPC-r38-1-linux_x86_64.pkg.tar.xz opt/devkitpro/devkitPPC --strip-components=1
+          tar -xf cache/devkitppc-rules-1.1.0-1-any.pkg.tar.xz opt/devkitpro/devkitPPC --strip-components=1
+          tar -xf cache/libogc-2.1.0-1-any.pkg.tar.xz opt/devkitpro/libogc --strip-components=1
+          tar -xf cache/general-tools-1.2.0-1-linux.pkg.tar.xz opt/devkitpro/tools/bin/bin2s --strip-components=4
+          sudo cp bin2s /usr/local/bin/bin2s
+          tar -xf cache/gamecube-tools-1.0.2-1-linux.pkg.tar.xz opt/devkitpro/tools/bin/elf2dol --strip-components=4
+          sudo cp elf2dol /usr/local/bin/elf2dol
+
+      - name: Compile
+        run: |
+          PATH=$(pwd)/devkitpro/devkitPPC/bin:$PATH DEVKITPPC=$(pwd)/devkitpro/devkitPPC DEVKITPRO=$(pwd)/devkitpro make
+
+      - name: Upload binaries
+        uses: actions/upload-artifact@v2
+        with: 
+          name: usbloadergx
+          path: |
+            boot.dol
+            boot.elf


### PR DESCRIPTION
Now that the USB-Loader GX can successfully be compiled with the latest devkitPPC version, it's probably a good idea to add a CI, just like with WiiFlow Lite. 

This will download the current version of devkitPPC from my server once and store them in the Github cache, then for any subsequent runs devkitPPC is loaded from the cache. Then, for every commit, Github will spin up a VM and compile the USB Loader GX, and provide DOL and ELF binaries. 

Other than with the Docker command referred in #5, this method will continue working even when newer versions of devkitPPC or libogc are released, as the versions used for the CI build are hardcoded in the file. 

If you wanted to be completely independant from my wii.leseratte10.de server you could also upload the needed files elsewhere (like in a Github release) and change the URLs in the config file. 