### PR TITLE
Fix IOS Reload not working with some cIOS

### DIFF
--- a/source/system/IosLoader.cpp
+++ b/source/system/IosLoader.cpp
@@ -190,8 +190,7 @@ s32 IosLoader::ReloadIosKeepingRights(s32 ios)
 
 		/* Disable MEM 2 protection */
 		write16(MEM2_PROT, 2);
-
-		for (u16 *patchme = ES_MODULE_START; patchme < ES_MODULE_END; patchme++)
+		for (u16 *patchme = (u16*)*((u32*)0x80003134); patchme < (u16*)0x94000000; patchme++)
 		{
 			if (!memcmp(patchme, ticket_check, sizeof(ticket_check)))
 			{


### PR DESCRIPTION
As of commit 0114bc2da4e604e3e608efb667b2a30e73811c2f the USB Loader failed to properly reload to IOS58 while keeping the additional AHBPROT rights after it loaded to a d2x v6 cIOS. 

This PR takes the patching logic from libruntimeiospatch instead of the existing one, which seems to work more reliably, at least on my console and with my installed cIOS versions. 