### PR TITLE
Cleanup and improve StartUpProcess

### DIFF
--- a/source/system/IosLoader.cpp
+++ b/source/system/IosLoader.cpp
@@ -177,7 +177,6 @@ s32 IosLoader::ReloadIosSafe(s32 ios)
  */
 s32 IosLoader::ReloadIosKeepingRights(s32 ios)
 {
-	bool patched;
 	if (CheckAHBPROT())
 	{
 		static const u16 ticket_check[] = {
@@ -200,7 +199,6 @@ s32 IosLoader::ReloadIosKeepingRights(s32 ios)
 
 				/* Apply patch */
 				patchme[ES_HACK_OFFSET] = 0x23FF; // li r3, 0xFF ; Set full access rights
-				patched = true;
 
 				/* Flush cache */
 				DCFlushRange(patchme+ES_HACK_OFFSET, 2);
@@ -208,8 +206,6 @@ s32 IosLoader::ReloadIosKeepingRights(s32 ios)
 			}
 		}
 	}
-	if (!patched)
-		IosPatch_AHBPROT(false);
 	// Reload IOS. MEM2 protection is implicitly re-enabled
 	return IOS_ReloadIOS(ios);
 }


### PR DESCRIPTION
Changes to the Startup process as mentioned in my PM to blackb0x. 

IOS Reloading logic has been rewritten to be more reliable. 

Previously, the new builds of the USB Loader GX either worked on my console (69de88361027295116ce606c55f71379a9c1a09e) and failed on Gabberhead's console, or they failed on mine and worked on his (37e00bb8abbf049846c5bcc39af8b74add0e8167). 

With this PR, the loader should work in both cases. There is no longer a useless reload to IOS249 while booting (unless it's required for an old forwarder), and there are no more useless IOS Reloads. 