### PR TITLE
Support Devolution's progressive patching

### DIFF
--- a/source/GameCube/DEVO_Config.h
+++ b/source/GameCube/DEVO_Config.h
@@ -20,7 +20,7 @@
 #define LAUNCH_DEVO() ((void(*)(void))loader_bin)()
 
 #define DEVO_SIG				 0x3EF9DB23
-#define DEVO_CONFIG_VERSION		 0x0200
+#define DEVO_CONFIG_VERSION		 0x0201
 
 enum DEVOConfig
 {
@@ -33,6 +33,8 @@ enum DEVOConfig
 	DEVO_CFG_CROP_OVERSCAN	= (1<<6), // added in Devo r234, config version 0x0200
 	DEVO_CFG_DISC_DELAY		= (1<<7),
 	DEVO_CFG_PLAYLOG		= (1<<8),
+	DEVO_CFG_FORCE_480P             = (1<<9), // probably added in Devo r266, config version 0x0201
+	DEVO_CFG_FORCE_576P             = (1<<10),
 };
 
 typedef struct _DEVO_CFG

--- a/source/settings/menus/GCGameLoadSM.cpp
+++ b/source/settings/menus/GCGameLoadSM.cpp
@@ -226,6 +226,7 @@ void GCGameLoadSM::SetOptionNames()
 		Options->SetName(Idx++, "%s", tr( "D Buttons" ));
 		Options->SetName(Idx++, "%s", tr( "Crop Overscan" ));
 		Options->SetName(Idx++, "%s", tr( "Disc Read Delay" ));
+		Options->SetName(Idx++, "%s", tr( "Progressive Patch" ));
 	}
 }
 
@@ -554,6 +555,12 @@ void GCGameLoadSM::SetOptionValues()
 			Options->SetValue(Idx++, tr("Use global"));
 		else
 			Options->SetValue(Idx++, "%s", tr(OnOffText[GameConfig.DEVODiscDelay]));
+
+		//! Settings: DML + NIN + Devo Progressive Patch
+		if(GameConfig.DMLProgPatch == INHERIT)
+			Options->SetValue(Idx++, tr("Use global"));
+		else
+			Options->SetValue(Idx++, "%s", tr(OnOffText[GameConfig.DMLProgPatch]));
 		
 	}
 }
@@ -947,6 +954,12 @@ int GCGameLoadSM::GetMenuInternal()
 	else if (currentGCmode == GC_MODE_DEVOLUTION && ret == ++Idx)
 	{
 		if (++GameConfig.DEVODiscDelay >= MAX_ON_OFF) GameConfig.DEVODiscDelay = INHERIT;
+	}
+
+	//! Settings: DEVO Progressive Patch
+	else if (currentGCmode == GC_MODE_DEVOLUTION && ret == ++Idx)
+	{
+		if (++GameConfig.DMLProgPatch >= MAX_ON_OFF) GameConfig.DMLProgPatch = INHERIT;
 	}
 
 	SetOptionValues();

--- a/source/settings/menus/LoaderSettings.cpp
+++ b/source/settings/menus/LoaderSettings.cpp
@@ -267,9 +267,9 @@ void LoaderSettings::SetOptionNames()
 	Options->SetName(Idx++, "%s", tr( "=== GameCube Settings" ));
 	Options->SetName(Idx++, "%s", tr( "GameCube Source" ));
 	Options->SetName(Idx++, "%s", tr( "GameCube Mode" ));
+	Options->SetName(Idx++, "%s", tr( "Progressive Patch" ));
 	Options->SetName(Idx++, "%s", tr( "--==  DM(L) + Nintendont" ));
 	Options->SetName(Idx++, "%s", tr( "Video Mode" ));
-	Options->SetName(Idx++, "%s", tr( "Progressive Patch" ));
 	Options->SetName(Idx++, "%s", tr( "Force Widescreen" ));
 	Options->SetName(Idx++, "%s", tr( "Debug" ));
 	Options->SetName(Idx++, "%s", tr( "Disc-Select Prompt" ));
@@ -413,14 +413,14 @@ void LoaderSettings::SetOptionValues()
 	//! Settings: GameCube Mode
 	Options->SetValue(Idx++, "%s", tr(GCMode[Settings.GameCubeMode]));
 
+	//! Settings: DML + NIN + Devo Progressive Patch
+	Options->SetValue(Idx++, "%s", tr(OnOffText[Settings.DMLProgPatch]));
+
 	//! Settings: TITLE - GameCube DIOS MIOS (Lite) + Nintendont
 	Options->SetValue(Idx++, "==--   ");
 
 	//! Settings: DML + NIN Video Mode
 	Options->SetValue(Idx++, "%s", tr(DMLVideoText[Settings.DMLVideo]));
-
-	//! Settings: DML + NIN Progressive Patch
-	Options->SetValue(Idx++, "%s", tr(OnOffText[Settings.DMLProgPatch]));
 
 	//! Settings: DML + NIN Force Widescreen
 	Options->SetValue(Idx++, "%s", tr(OnOffText[Settings.DMLWidescreen]));
@@ -777,6 +777,12 @@ int LoaderSettings::GetMenuInternal()
 		if (++Settings.GameCubeMode >= CG_MODE_MAX_CHOICE) Settings.GameCubeMode = 0;
 	}
 
+	//! Settings: DML + NIN + Devo Progressive Patch
+	else if (ret == ++Idx)
+	{
+		if (++Settings.DMLProgPatch >= MAX_ON_OFF) Settings.DMLProgPatch = 0;
+	}
+
 	//! Settings: TITLE - GameCube DM(L) + Nintendont
 	else if (ret == ++Idx)
 	{
@@ -790,12 +796,6 @@ int LoaderSettings::GetMenuInternal()
 		if(Settings.DMLVideo == DML_VIDEO_FORCE_PATCH) // Skip Force Patch
 			Settings.DMLVideo++;
 		if(Settings.DMLVideo >= DML_VIDEO_MAX_CHOICE) Settings.DMLVideo = 0;
-	}
-
-	//! Settings: DML + NIN Progressive Patch
-	else if (ret == ++Idx)
-	{
-		if (++Settings.DMLProgPatch >= MAX_ON_OFF) Settings.DMLProgPatch = 0;
 	}
 
 	//! Settings: DML + NIN Force Widescreen

--- a/source/usbloader/GameBooter.cpp
+++ b/source/usbloader/GameBooter.cpp
@@ -810,6 +810,7 @@ int GameBooter::BootDevolution(struct discHdr *gameHdr)
 
 	GameCFG * game_cfg = GameSettings.GetGameCFG(gameHdr->id);
 	s8 languageChoice = game_cfg->language == INHERIT ? Settings.language -1 : game_cfg->language;
+	u8 devoProgressivePatch = game_cfg->DMLProgPatch == INHERIT ? Settings.DMLProgPatch : game_cfg->DMLProgPatch;
 	u8 devoMCEmulation = game_cfg->DEVOMCEmulation == INHERIT ? Settings.DEVOMCEmulation : game_cfg->DEVOMCEmulation;
 	u8 devoActivityLEDChoice = game_cfg->DEVOActivityLED == INHERIT ? Settings.DEVOActivityLED : game_cfg->DEVOActivityLED;
 	u8 devoWidescreenChoice = game_cfg->DEVOWidescreen == INHERIT ? Settings.DEVOWidescreen : game_cfg->DEVOWidescreen;
@@ -944,6 +945,11 @@ int GameBooter::BootDevolution(struct discHdr *gameHdr)
 	if (devoDiscDelayChoice && DEVO_version >= 234)
 		devo_config->options |= DEVO_CFG_DISC_DELAY;
 	//	devo_config->options |= DEVO_CFG_PLAYLOG; 			// Playlog setting managed by USBLoaderGX features menu
+	if (devoProgressivePatch && DEVO_version >= 266)
+	{
+		devo_config->options |= DEVO_CFG_FORCE_480P;
+		devo_config->options |= DEVO_CFG_FORCE_576P;
+	}
 	
 	// check memory card
 	if(devoMCEmulation == DEVO_MC_OFF)


### PR DESCRIPTION
At some point between r239 and r266, Devolution added progressive patching.

I've bumped the devo config version to 0x0201 and added the forced progressive bits, and added the Progressive Patch option to the per-game Devo menu.

As all three homebrew loaders support it now, I've moved the global option under the top-level GameCube Settings menu (obviously a stock MIOS won't support it, but meh).
