### PR TITLE
Add options to autoboot from disc

### DIFF
--- a/source/StartUpProcess.cpp
+++ b/source/StartUpProcess.cpp
@@ -24,13 +24,11 @@
 #include "usbloader/GameList.h"
 #include "usbloader/wdvd.h"
 #include "utils/tools.h"
-#include "utils/ShowError.h"
 #include "sys.h"
 #include "svnrev.h"
 #include "gitver.h"
 #include "usbloader/sdhc.h"
 #include "settings/meta.h"
-#include "language/gettext.h"
 
 extern bool isWiiVC; // in sys.cpp
 extern u8 sdhc_mode_sd;
@@ -72,10 +70,6 @@ StartUpProcess::StartUpProcess()
 	cancelTxt->SetAlignment(ALIGN_CENTER, ALIGN_MIDDLE);
 	cancelTxt->SetPosition(screenwidth / 2, screenheight / 2 + 90);
 
-	discCancelTxt = new GuiText("Press B to cancel", 22, (GXColor){255, 255, 255, 255});
-	discCancelTxt->SetAlignment(ALIGN_CENTER, ALIGN_MIDDLE);
-	discCancelTxt->SetPosition(screenwidth / 2, screenheight / 2 + 90);
-
 	trigB = new GuiTrigger;
 	trigB->SetButtonOnlyTrigger(-1, WPAD_BUTTON_B | WPAD_CLASSIC_BUTTON_B, PAD_BUTTON_B);
 
@@ -90,7 +84,6 @@ StartUpProcess::StartUpProcess()
 		sdmodeBtn->SetTrigger(trigA);
 
 	drawCancel = false;
-	drawDiscCancel = false;
 }
 
 StartUpProcess::~StartUpProcess()
@@ -102,7 +95,6 @@ StartUpProcess::~StartUpProcess()
 	delete messageTxt;
 	delete versionTxt;
 	delete cancelTxt;
-	delete discCancelTxt;
 	delete cancelBtn;
 	delete sdmodeBtn;
 	delete trigB;
@@ -357,6 +349,7 @@ int StartUpProcess::Execute(bool quickGameBoot)
 	{
 		Settings.USBAutoMount = ON;
 		Settings.LoaderMode = MODE_ALL;
+		Settings.AutobootDiscs = OFF;
 		Settings.skipSaving = true;
 	}
 
@@ -436,36 +429,51 @@ int StartUpProcess::Execute(bool quickGameBoot)
 	SetTextf("Checking installed MIOS\n");
 	IosLoader::GetMIOSInfo();
 
-	if (Settings.AutobootDiscs == ON) {
-		drawDiscCancel = true;
+	if (Settings.AutobootDiscs == ON)
+	{
 		Timer countDown;
 		bool skipDiscAutoboot = false;
+		s32 delay = 0;
+		u32 DiscDriveCover = 0;
 
-		do
+		Disc_Init();
+		WDVD_GetCoverStatus(&DiscDriveCover);
+		if (DiscDriveCover & 0x02)
 		{
-			UpdatePads();
-			for (int i = 0; i < 4; ++i)
+			drawCancel = true;
+			gprintf("Disc found in drive\n");
+			cancelTxt->SetText("Press B to cancel");
+			do
 			{
-				cancelBtn->Update(&userInput[i]);
-			}
-			if (cancelBtn->GetState() == STATE_CLICKED) {
-				skipDiscAutoboot = true;
-				break;
-			}
+				UpdatePads();
+				for (int i = 0; i < 4; ++i)
+					cancelBtn->Update(&userInput[i]);
+				if (cancelBtn->GetState() == STATE_CLICKED)
+				{
+					skipDiscAutoboot = true;
+					break;
+				}
 
-			messageTxt->SetTextf("Autobooting from Disc in: %i sec\n", Settings.AutobootDiscsDelay - (int)countDown.elapsed());
-			Draw();
-			usleep(50000);
-		} while (countDown.elapsed() < (float)Settings.AutobootDiscsDelay);
+				delay = Settings.AutobootDiscsDelay - (int)countDown.elapsed();
+				messageTxt->SetTextf("Booting from disc in %d second%s\n", delay, delay > 1 ? "s" : "");
+				Draw();
+				usleep(50000);
+			} while (countDown.elapsed() < (float)Settings.AutobootDiscsDelay);
 
-		drawDiscCancel = false;
-		if (skipDiscAutoboot == false) {
-			messageTxt->SetTextf("Autobooting from Disc\n");
-			Draw();
-			return this->AutobootDisc();
+			drawCancel = false;
+			if (skipDiscAutoboot == false)
+			{
+				messageTxt->SetTextf("Booting from disc\n");
+				Draw();
+				return AutobootDisc();
+			}
+		}
+		else
+		{
+			gprintf("No disc found in drive\n");
+			WDVD_Close();
 		}
 	}
-
 	return FinalizeExecute();
 }
 
@@ -503,8 +511,6 @@ void StartUpProcess::Draw()
 	versionTxt->Draw();
 	if (drawCancel)
 		cancelTxt->Draw();
-	if (drawDiscCancel)
-		discCancelTxt->Draw();
 	Menu_Render();
 }
 
@@ -530,30 +536,19 @@ int StartUpProcess::QuickGameBoot(const char *gameID)
 
 int StartUpProcess::AutobootDisc()
 {
-	Disc_Init();
-
-	u32 DiscDriveCover = 0;
-	WDVD_GetCoverStatus(&DiscDriveCover);
-
-	if (DiscDriveCover & 0x02) {
-		struct discHdr* header = new struct discHdr;
-		if (Disc_Mount(header) < 0)
-		{
-			delete header;
-			header = NULL;
-			SetTextf("Error Mounting Disc\n");
-			usleep(3000000);	//~3 seconds in Dolphin
-			return FinalizeExecute();
-		}
-		else
-		{
-			GameStatistics.SetPlayCount(header->id, GameStatistics.GetPlayCount(header->id) + 1);
-			GameStatistics.Save();
-
-			return GameBooter::BootGame(header);
-		}
-	}
-	else {
+	struct discHdr *header = new struct discHdr;
+	if (Disc_Mount(header) < 0)
+	{
+		delete header;
+		header = NULL;
+		SetTextf("Error mounting disc\n");
+		sleep(3);
 		return FinalizeExecute();
+	}
+	else
+	{
+		GameStatistics.SetPlayCount(header->id, GameStatistics.GetPlayCount(header->id) + 1);
+		GameStatistics.Save();
+		return GameBooter::BootGame(header);
 	}
 }

--- a/source/StartUpProcess.h
+++ b/source/StartUpProcess.h
@@ -13,14 +13,17 @@ private:
 	~StartUpProcess();
 	void LoadIOS(u8 ios, bool boot);
 	int Execute(bool quickGameBoot);
+	int FinalizeExecute();
 	bool USBSpinUp();
 	void TextFade(int direction);
 	void SetTextf(const char *format, ...);
 	void Draw();
 	static int ParseArguments(int argc, char *argv[]);
 	static int QuickGameBoot(const char *gameID);
+	int AutobootDisc();
 
 	bool drawCancel;
+	bool drawDiscCancel;
 
 	GuiImageData *GXImageData;
 	GuiImage *background;
@@ -29,6 +32,7 @@ private:
 	GuiText *messageTxt;
 	GuiText *versionTxt;
 	GuiText *cancelTxt;
+	GuiText *discCancelTxt;
 	GuiButton *cancelBtn;
 	GuiButton *sdmodeBtn;
 	GuiTrigger *trigB;

--- a/source/StartUpProcess.h
+++ b/source/StartUpProcess.h
@@ -23,7 +23,6 @@ private:
 	int AutobootDisc();
 
 	bool drawCancel;
-	bool drawDiscCancel;
 
 	GuiImageData *GXImageData;
 	GuiImage *background;
@@ -32,7 +31,6 @@ private:
 	GuiText *messageTxt;
 	GuiText *versionTxt;
 	GuiText *cancelTxt;
-	GuiText *discCancelTxt;
 	GuiButton *cancelBtn;
 	GuiButton *sdmodeBtn;
 	GuiTrigger *trigB;

--- a/source/menu/menu_install.cpp
+++ b/source/menu/menu_install.cpp
@@ -6,6 +6,7 @@
 #include "usbloader/wbfs.h"
 #include "usbloader/disc.h"
 #include "usbloader/GameList.h"
+#include "usbloader/wdvd.h"
 #include "prompts/ProgressWindow.h"
 #include "prompts/GCMultiDiscMenu.h"
 #include "themes/CTheme.h"
@@ -216,6 +217,11 @@ int MenuInstall()
 	if (ret < 0)
 	{
 		WindowPrompt(tr( "Error reading Disc" ), 0, tr( "Back" ));
+		return MENU_DISCLIST;
+	}
+	ret = WDVD_Reset();
+	if (ret < 0) {
+		WindowPrompt(tr( "Error resetting disc drive" ), 0, tr( "Back" ));
 		return MENU_DISCLIST;
 	}
 	ret = Disc_Open();

--- a/source/menu/menu_install.cpp
+++ b/source/menu/menu_install.cpp
@@ -6,7 +6,6 @@
 #include "usbloader/wbfs.h"
 #include "usbloader/disc.h"
 #include "usbloader/GameList.h"
-#include "usbloader/wdvd.h"
 #include "prompts/ProgressWindow.h"
 #include "prompts/GCMultiDiscMenu.h"
 #include "themes/CTheme.h"
@@ -219,12 +218,7 @@ int MenuInstall()
 		WindowPrompt(tr( "Error reading Disc" ), 0, tr( "Back" ));
 		return MENU_DISCLIST;
 	}
-	ret = WDVD_Reset();
-	if (ret < 0) {
-		WindowPrompt(tr( "Error resetting disc drive" ), 0, tr( "Back" ));
-		return MENU_DISCLIST;
-	}
-	ret = Disc_Open();
+	ret = Disc_Open(true);
 	if (ret < 0)
 	{
 		WindowPrompt(tr( "Could not open Disc" ), 0, tr( "Back" ));

--- a/source/settings/CSettings.cpp
+++ b/source/settings/CSettings.cpp
@@ -169,6 +169,8 @@ void CSettings::SetDefault()
 	NandEmuMode = OFF;
 	NandEmuChanMode = 2;
 	UseSystemFont = ON;
+	AutobootDiscs = OFF;
+	AutobootDiscsDelay = 3;
 	Hooktype = 0;
 	WiirdDebugger = OFF;
 	WiirdDebuggerPause = OFF;
@@ -439,6 +441,8 @@ bool CSettings::Save()
 	fprintf(file, "NandEmuPath = %s\n", NandEmuPath);
 	fprintf(file, "NandEmuChanPath = %s\n", NandEmuChanPath);
 	fprintf(file, "UseSystemFont = %d\n", UseSystemFont);
+	fprintf(file, "AutobootDiscs = %d\n", AutobootDiscs);
+	fprintf(file, "AutobootDiscsDelay = %d\n", AutobootDiscsDelay);
 	fprintf(file, "Hooktype = %d\n", Hooktype);
 	fprintf(file, "WiirdDebugger = %d\n", WiirdDebugger);
 	fprintf(file, "WiirdDebuggerPause = %d\n", WiirdDebuggerPause);
@@ -866,6 +870,14 @@ bool CSettings::SetSetting(char *name, char *value)
 	else if(strcmp(name, "UseSystemFont") == 0)
 	{
 		UseSystemFont = atoi(value);
+	}
+	else if (strcmp(name, "AutobootDiscs") == 0)
+	{
+		AutobootDiscs = atoi(value);
+	}
+	else if (strcmp(name, "AutobootDiscsDelay") == 0)
+	{
+		AutobootDiscsDelay = atoi(value);
 	}
 	else if(strcmp(name, "Hooktype") == 0)
 	{

--- a/source/settings/CSettings.h
+++ b/source/settings/CSettings.h
@@ -175,6 +175,8 @@ class CSettings
 		short NandEmuMode;
 		short NandEmuChanMode;
 		short UseSystemFont;
+		short AutobootDiscs;
+		short AutobootDiscsDelay;
 		short Hooktype;
 		short WiirdDebugger;
 		short WiirdDebuggerPause;

--- a/source/settings/menus/GUISettingsMenu.cpp
+++ b/source/settings/menus/GUISettingsMenu.cpp
@@ -159,6 +159,8 @@ GuiSettingsMenu::GuiSettingsMenu()
 	Options->SetName(Idx++, "%s", tr( "Show Game Count" ));
 	Options->SetName(Idx++, "%s", tr( "HOME Menu" ));
 	Options->SetName(Idx++, "%s", tr( "Use System Font" ));
+	Options->SetName(Idx++, "%s", tr( "Autoboot Discs" ));
+	Options->SetName(Idx++, "%s", tr( "Autoboot Discs Delay" ));
 	Options->SetName(Idx++, "%s", tr( "Virtual Pointer Speed" ));
 	Options->SetName(Idx++, "%s", tr( "Adjust Overscan X" ));
 	Options->SetName(Idx++, "%s", tr( "Adjust Overscan Y" ));
@@ -253,6 +255,12 @@ void GuiSettingsMenu::SetOptionValues()
 
 	//! Settings: Use System Font
 	Options->SetValue(Idx++, "%s", tr( OnOffText[Settings.UseSystemFont] ));
+
+	//! Settings: Autoboot Discs
+	Options->SetValue(Idx++, "%s", tr( OnOffText[Settings.AutobootDiscs] ));
+
+	//! Settings: Autoboot Discs Delay
+	Options->SetValue(Idx++, "%i", Settings.AutobootDiscsDelay);
 
 	//! Settings: Virtual Pointer Speed
 	Options->SetValue(Idx++, "%g", Settings.PointerSpeed);
@@ -482,6 +490,18 @@ int GuiSettingsMenu::GetMenuInternal()
 			Settings.FontScaleFactor = 0.8f;
 		else if(Settings.FontScaleFactor == 0.8f && Settings.UseSystemFont == OFF)
 			Settings.FontScaleFactor = 1.0f;
+	}
+
+	//! Settings: Autoboot Discs
+	else if (ret == ++Idx)
+	{
+		if (++Settings.AutobootDiscs >= MAX_ON_OFF) Settings.AutobootDiscs = 0;
+	}
+
+	//! Settings: Autoboot Discs Delay
+	else if (ret == ++Idx)
+	{
+		if (++Settings.AutobootDiscsDelay >= 6) Settings.AutobootDiscsDelay = 0;
 	}
 
 	//! Settings: Virtual Pointer Speed

--- a/source/settings/menus/GUISettingsMenu.cpp
+++ b/source/settings/menus/GUISettingsMenu.cpp
@@ -159,8 +159,6 @@ GuiSettingsMenu::GuiSettingsMenu()
 	Options->SetName(Idx++, "%s", tr( "Show Game Count" ));
 	Options->SetName(Idx++, "%s", tr( "HOME Menu" ));
 	Options->SetName(Idx++, "%s", tr( "Use System Font" ));
-	Options->SetName(Idx++, "%s", tr( "Autoboot Discs" ));
-	Options->SetName(Idx++, "%s", tr( "Autoboot Discs Delay" ));
 	Options->SetName(Idx++, "%s", tr( "Virtual Pointer Speed" ));
 	Options->SetName(Idx++, "%s", tr( "Adjust Overscan X" ));
 	Options->SetName(Idx++, "%s", tr( "Adjust Overscan Y" ));
@@ -255,12 +253,6 @@ void GuiSettingsMenu::SetOptionValues()
 
 	//! Settings: Use System Font
 	Options->SetValue(Idx++, "%s", tr( OnOffText[Settings.UseSystemFont] ));
-
-	//! Settings: Autoboot Discs
-	Options->SetValue(Idx++, "%s", tr( OnOffText[Settings.AutobootDiscs] ));
-
-	//! Settings: Autoboot Discs Delay
-	Options->SetValue(Idx++, "%i", Settings.AutobootDiscsDelay);
 
 	//! Settings: Virtual Pointer Speed
 	Options->SetValue(Idx++, "%g", Settings.PointerSpeed);
@@ -490,18 +482,6 @@ int GuiSettingsMenu::GetMenuInternal()
 			Settings.FontScaleFactor = 0.8f;
 		else if(Settings.FontScaleFactor == 0.8f && Settings.UseSystemFont == OFF)
 			Settings.FontScaleFactor = 1.0f;
-	}
-
-	//! Settings: Autoboot Discs
-	else if (ret == ++Idx)
-	{
-		if (++Settings.AutobootDiscs >= MAX_ON_OFF) Settings.AutobootDiscs = 0;
-	}
-
-	//! Settings: Autoboot Discs Delay
-	else if (ret == ++Idx)
-	{
-		if (++Settings.AutobootDiscsDelay >= 6) Settings.AutobootDiscsDelay = 0;
 	}
 
 	//! Settings: Virtual Pointer Speed

--- a/source/settings/menus/LoaderSettings.cpp
+++ b/source/settings/menus/LoaderSettings.cpp
@@ -287,6 +287,8 @@ void LoaderSettings::SetOptionNames()
 	Options->SetName(Idx++, "%s", tr( "Wiird Debugger" ));
 	Options->SetName(Idx++, "%s", tr( "Debugger Paused Start" ));
 	Options->SetName(Idx++, "%s", tr( "Channel Launcher" ));
+	Options->SetName(Idx++, "%s", tr( "Autoboot Discs" ));
+	Options->SetName(Idx++, "%s", tr( "Autoboot Discs Delay" ));
 	Options->SetName(Idx++, "%s", tr( "=== GameCube Settings" ));
 	Options->SetName(Idx++, "%s", tr( "GameCube Source" ));
 	Options->SetName(Idx++, "%s", tr( "GameCube Mode" ));
@@ -437,6 +439,12 @@ void LoaderSettings::SetOptionValues()
 
 	//! Settings: Channel Launcher
 	Options->SetValue(Idx++, "%s", tr( ChannelLaunchText[Settings.UseChanLauncher] ));
+
+	//! Settings: Autoboot Discs
+	Options->SetValue(Idx++, "%s", tr( OnOffText[Settings.AutobootDiscs] ));
+
+	//! Settings: Autoboot Discs Delay
+	Options->SetValue(Idx++, "%i", Settings.AutobootDiscsDelay);
 
 	//! Settings: TITLE - GameCube Settings
 	Options->SetValue(Idx++, "=======");
@@ -816,6 +824,18 @@ int LoaderSettings::GetMenuInternal()
 	else if (ret == ++Idx )
 	{
 		if (++Settings.UseChanLauncher >= MAX_ON_OFF) Settings.UseChanLauncher = 0;
+	}
+
+	//! Settings: Autoboot Discs
+	else if (ret == ++Idx)
+	{
+		if (++Settings.AutobootDiscs >= MAX_ON_OFF) Settings.AutobootDiscs = 0;
+	}
+
+	//! Settings: Autoboot Discs Delay
+	else if (ret == ++Idx)
+	{
+		if (++Settings.AutobootDiscsDelay >= 6) Settings.AutobootDiscsDelay = 0;
 	}
 
 	//! Settings: TITLE - GameCube Settings

--- a/source/usbloader/GameBooter.cpp
+++ b/source/usbloader/GameBooter.cpp
@@ -226,7 +226,7 @@ int GameBooter::SetupDisc(struct discHdr &gameHeader)
 	if (gameHeader.type == TYPE_GAME_WII_DISC)
 	{
 		gprintf("Loading DVD\n");
-		return Disc_Open();
+		return Disc_Open(false);
 	}
 
 	int ret = -1;
@@ -253,7 +253,7 @@ int GameBooter::SetupDisc(struct discHdr &gameHeader)
 	}
 
 	gprintf("Disc_Open()...");
-	ret = Disc_Open();
+	ret = Disc_Open(false);
 	gprintf("%d\n", ret);
 
 	return ret;

--- a/source/usbloader/disc.c
+++ b/source/usbloader/disc.c
@@ -263,12 +263,6 @@ s32 Disc_Init(void)
 
 s32 Disc_Open(void)
 {
-	s32 ret;
-
-	/* Reset drive */
-	ret = WDVD_Reset();
-	if (ret < 0) return ret;
-
 	/* Read disc ID */
 	return WDVD_ReadDiskId(diskid);
 }

--- a/source/usbloader/disc.c
+++ b/source/usbloader/disc.c
@@ -261,8 +261,16 @@ s32 Disc_Init(void)
 	return WDVD_Init();
 }
 
-s32 Disc_Open(void)
+s32 Disc_Open(bool reset)
 {
+	/* Reset drive */
+	if (reset)
+	{
+		s32 ret = WDVD_Reset();
+		if (ret < 0)
+			return ret;
+	}
+
 	/* Read disc ID */
 	return WDVD_ReadDiskId(diskid);
 }

--- a/source/usbloader/disc.h
+++ b/source/usbloader/disc.h
@@ -55,7 +55,7 @@ extern "C"
 
 	/* Prototypes */
 	s32 Disc_Init(void);
-	s32 Disc_Open(void);
+	s32 Disc_Open(bool reset);
 	s32 Disc_Wait(void);
 	void Disc_SetLowMem(void);
 	s32 Disc_SetUSB(const u8 *);


### PR DESCRIPTION
This pull request is intended to:

- Eliminate an unnecessary disc drive reset when loading games from disc.
  - A manual reset is added for the Install Disc prompt where the reset is actually needed if a disc is already in the drive.
- Add two options in the GUI Settings menu:
  - Autoboot Discs- This will attempt to autoboot a game disc during the initial splash loading screen.  The user is shown a "Press B to cancel" prompt to skip the autoboot process, with a countdown timer identical to the 20 second waiting for HDD prompt when not in SD card mode.  Defaults to OFF.
  - Autoboot Discs Delay- This is the time in seconds that the prompt will be shown before attempting to boot from disc, selectable from 0-5 seconds.  Defaults to 3 seconds.

Some notes/things you may want to change:

- drawCancel and cancelTxt in StartUpProcess.cpp can probably be re-used for the "Press B to cancel" message.
- You may want to remove the short wait after a potential disc mounting failure in AutobootDisc()- depends on if the rest of the project often shows error messages to users, or if the delay is too long on real hardware.
- Initialization functions past the "Loading Resources" message were moved to avoid a font reload making the autoboot prompt look very strange (any message past text loading would be affected by this).