### PR TITLE
fix shared content installation flow

### DIFF
--- a/source/wad/wad.cpp
+++ b/source/wad/wad.cpp
@@ -322,7 +322,7 @@ bool Wad::InstallContents(const char *installpath)
 		// Install content
 		if(content->type == 0x8001) {
 			// shared content
-			int result = CheckContentMap(installpath, content, filepath);
+			int result = UpdateContentMap(installpath, content, filepath);
 			if(result == 1) // exists already, skip file
 				continue;
 
@@ -448,6 +448,16 @@ int Wad::CheckContentMap(const char *installpath, tmd_content *content, char *fi
 			return 1; // content exists already
 	}
 
+	// Content does not exists
+	return 0;
+}
+
+int Wad::UpdateContentMap(const char *installpath, tmd_content *content, char *filepath)
+{
+	int result = CheckContentMap(installpath,content,filepath); 
+	if ( result != 0 )
+		return result; // content already exists or error
+
 	// Content does not exists, append it.
 	u32 next_entry = content_map_size;
 	u8 *tmp = (u8 *) realloc(content_map, (next_entry + 1) * sizeof(map_entry_t));
@@ -461,7 +471,7 @@ int Wad::CheckContentMap(const char *installpath, tmd_content *content, char *fi
 	content_map = tmp;
 	content_map_size++;
 
-	map = (map_entry_t *) content_map;
+	map_entry_t *map = (map_entry_t *) content_map;
 	char name[9];
 	sprintf(name, "%08x", (unsigned int)next_entry);
 	memcpy(map[next_entry].name, name, 8);

--- a/source/wad/wad.cpp
+++ b/source/wad/wad.cpp
@@ -322,13 +322,14 @@ bool Wad::InstallContents(const char *installpath)
 		// Install content
 		if(content->type == 0x8001) {
 			// shared content
-			int result = UpdateContentMap(installpath, content, filepath);
+			int result = CheckContentMap(installpath, content, filepath); 
 			if(result == 1) // exists already, skip file
 				continue;
 
 			else if(result < 0) // failure
 				return false;
 			// else it does not exist...install it
+			snprintf(filepath, sizeof(filepath), "%s/shared1/%08x.app", installpath, (unsigned int)content_map_size);
 		}
 		else {
 			// private content
@@ -419,6 +420,16 @@ bool Wad::InstallContents(const char *installpath)
 				ShowError(tr("File read/write error."));
 			return false;
 		}
+
+		if(content->type == 0x8001) {
+			// shared content installed ok. It's time to update content.map
+			int result = UpdateContentMap(installpath, content, filepath); 
+			if(result == 1) // exists already, skip file
+				continue;
+
+			else if(result < 0) // failure
+				return false;
+		}
 	}
 
 	return true;
@@ -481,8 +492,6 @@ int Wad::UpdateContentMap(const char *installpath, tmd_content *content, char *f
 	snprintf(filepath, 1024, "%s/shared1/content.map", installpath);
 	if(!WriteFile(filepath, content_map, content_map_size * sizeof(map_entry_t)))
 		return -1;
-
-	snprintf(filepath, 1024, "%s/shared1/%08x.app", installpath, (unsigned int)next_entry);
 
 	return 0;
 }

--- a/source/wad/wad.h
+++ b/source/wad/wad.h
@@ -49,6 +49,7 @@ public:
 private:
 	bool InstallContents(const char *installpath);
 	int CheckContentMap(const char *installpath, tmd_content *content, char *filepath);
+	int UpdateContentMap(const char *installpath, tmd_content *content, char *filepath);
 	bool WriteFile(const char *filepath, u8 *buffer, u32 len);
 	bool SetTitleUID(const char *intallpath, const u64 &tid);
 


### PR DESCRIPTION
The eumunand wad manager does not install the shared content part of any wad. 

During wad installation, for each shared content found, the function CheckContentMap is called twice to decide if some action is needed:
- when adjusting the progress bar
- before installing any shared content

CheckContentMap verifies if the shared content  is installed by looking for it in  shared1/content.map file. If not found, it adds its hash to the content.map file but performs no  installation (which is delegated to other part of the code).

Assume that a wad has  a shared content that is not installed in the emunand. First call to CheckContentMap won't find it and will update content.map. Second call to  CheckContentMap will find the entry for the shared content in the content.map file and will assume that it is already installed, so shared content installation is always skipped!

To fix this issue, I've separated the check and update functionalities of CheckContentMap in two different functions: CheckContentMap and UpdateContentMap, so the content.map file is only updated right before the installation of the shared content.
 