### PR TITLE
some fixes: avoid black banners / minimize one usb related dsi exceptions / get custom banners / install shared content 

### DIFF
--- a/source/Channels/channels.cpp
+++ b/source/Channels/channels.cpp
@@ -707,13 +707,22 @@ u8 *Channels::GetOpeningBnr(const u64 &title, u32 *outsize, const char *pathPref
     u32 high = TITLE_UPPER(title);
     u32 low = TITLE_LOWER(title);
 
+
+    // avoid black banners - add path prefix length to ISFS_MAXPATH when loading from emuNAND 
+    int customMaxPath;
+    if (pathPrefix && *pathPrefix != 0)
+            customMaxPath = ISFS_MAXPATH + strlen(pathPrefix);
+        else
+            customMaxPath = ISFS_MAXPATH;
+    
+    // avoid black banners - we don't change filepath definition, it was already of this size for both cases...
     char *filepath = (char *)memalign(32, ISFS_MAXPATH + strlen(pathPrefix));
     if (!filepath)
         return NULL;
 
     do
     {
-        snprintf(filepath, ISFS_MAXPATH, "%s/title/%08x/%08x/content/title.tmd", pathPrefix, (unsigned int)high, (unsigned int)low);
+        snprintf(filepath, customMaxPath, "%s/title/%08x/%08x/content/title.tmd", pathPrefix, (unsigned int)high, (unsigned int)low);
 
         u8 *buffer = NULL;
         u32 filesize = 0;
@@ -748,7 +757,7 @@ u8 *Channels::GetOpeningBnr(const u64 &title, u32 *outsize, const char *pathPref
         if (!found)
             break;
 
-        snprintf(filepath, ISFS_MAXPATH, "%s/title/%08x/%08x/content/%08x.app", pathPrefix, (unsigned int)high, (unsigned int)low, (unsigned int)bootcontent);
+        snprintf(filepath, customMaxPath, "%s/title/%08x/%08x/content/%08x.app", pathPrefix, (unsigned int)high, (unsigned int)low, (unsigned int)bootcontent);
 
         if (pathPrefix && *pathPrefix != 0)
             ret = LoadFileToMem(filepath, &buffer, &filesize);

--- a/source/menu/GameBrowseMenu.cpp
+++ b/source/menu/GameBrowseMenu.cpp
@@ -1693,12 +1693,15 @@ void GameBrowseMenu::UpdateCallback(void * e)
 
 void GameBrowseMenu::SetFreeSpace(float freespace, float used)
 {
-	if (  allowUsedSpaceTxtUpdate == true ) {
-		if (strcmp(Settings.db_language, "JA") == 0)
+	
+	if (strcmp(Settings.db_language, "JA") == 0) {
+		if (  allowUsedSpaceTxtUpdate == true ) 
 			usedSpaceTxt->SetText(fmt("%.2fGB %s %.2fGB %s", freespace + used, tr( "of" ), freespace, tr( "free" )));
-		else
-			usedSpaceTxt->SetText(fmt("%.2fGB %s %.2fGB %s", freespace, tr( "of" ), freespace + used, tr( "free" )));
 	}
+	else
+		if (  allowUsedSpaceTxtUpdate == true )
+			usedSpaceTxt->SetText(fmt("%.2fGB %s %.2fGB %s", freespace, tr( "of" ), freespace + used, tr( "free" )));
+	
 }
 
 void GameBrowseMenu::UpdateFreeSpace(void * arg)

--- a/source/menu/GameBrowseMenu.cpp
+++ b/source/menu/GameBrowseMenu.cpp
@@ -1693,13 +1693,12 @@ void GameBrowseMenu::UpdateCallback(void * e)
 
 void GameBrowseMenu::SetFreeSpace(float freespace, float used)
 {
-	if (strcmp(Settings.db_language, "JA") == 0) {
-		if (  allowUsedSpaceTxtUpdate == true )
+	if (  allowUsedSpaceTxtUpdate == true ) {
+		if (strcmp(Settings.db_language, "JA") == 0)
 			usedSpaceTxt->SetText(fmt("%.2fGB %s %.2fGB %s", freespace + used, tr( "of" ), freespace, tr( "free" )));
-	}
-	else
-		if (  allowUsedSpaceTxtUpdate == true )
+		else
 			usedSpaceTxt->SetText(fmt("%.2fGB %s %.2fGB %s", freespace, tr( "of" ), freespace + used, tr( "free" )));
+	}
 }
 
 void GameBrowseMenu::UpdateFreeSpace(void * arg)

--- a/source/settings/CSettings.cpp
+++ b/source/settings/CSettings.cpp
@@ -79,7 +79,7 @@ void CSettings::SetDefault()
 	strlcpy(GameCubePath, "usb1:/games/", sizeof(GameCubePath));
 	strlcpy(GameCubeSDPath, "sd:/games/", sizeof(GameCubeSDPath));
 	strlcpy(CustomAddress, "wiimmfi.de", sizeof(CustomAddress));
-	strlcpy(URL_Banners, "https://banner.rc24.xyz/", sizeof(URL_Banners));
+	strlcpy(URL_Banners, "http://banner.rc24.xyz/", sizeof(URL_Banners));
 	strlcpy(URL_Covers2D, "https://art.gametdb.com/wii/cover/", sizeof(URL_Covers2D));
 	strlcpy(URL_Covers3D, "https://art.gametdb.com/wii/cover3D/", sizeof(URL_Covers3D));
 	strlcpy(URL_CoversFull, "https://art.gametdb.com/wii/coverfull/", sizeof(URL_CoversFull));

--- a/source/wad/wad.cpp
+++ b/source/wad/wad.cpp
@@ -322,7 +322,7 @@ bool Wad::InstallContents(const char *installpath)
 		// Install content
 		if(content->type == 0x8001) {
 			// shared content
-			int result = CheckContentMap(installpath, content, filepath);
+			int result = UpdateContentMap(installpath, content, filepath);
 			if(result == 1) // exists already, skip file
 				continue;
 
@@ -448,6 +448,16 @@ int Wad::CheckContentMap(const char *installpath, tmd_content *content, char *fi
 			return 1; // content exists already
 	}
 
+	// Content does not exists
+	return 0;
+}
+
+int Wad::UpdateContentMap(const char *installpath, tmd_content *content, char *filepath)
+{
+	int result = CheckContentMap(installpath,content,filepath); 
+	if ( result != 0 )
+		return result; // content already exists or error
+
 	// Content does not exists, append it.
 	u32 next_entry = content_map_size;
 	u8 *tmp = (u8 *) realloc(content_map, (next_entry + 1) * sizeof(map_entry_t));
@@ -461,7 +471,7 @@ int Wad::CheckContentMap(const char *installpath, tmd_content *content, char *fi
 	content_map = tmp;
 	content_map_size++;
 
-	map = (map_entry_t *) content_map;
+	map_entry_t *map = (map_entry_t *) content_map;
 	char name[9];
 	sprintf(name, "%08x", (unsigned int)next_entry);
 	memcpy(map[next_entry].name, name, 8);

--- a/source/wad/wad.cpp
+++ b/source/wad/wad.cpp
@@ -322,13 +322,14 @@ bool Wad::InstallContents(const char *installpath)
 		// Install content
 		if(content->type == 0x8001) {
 			// shared content
-			int result = UpdateContentMap(installpath, content, filepath);
+			int result = CheckContentMap(installpath, content, filepath); 
 			if(result == 1) // exists already, skip file
 				continue;
 
 			else if(result < 0) // failure
 				return false;
 			// else it does not exist...install it
+			snprintf(filepath, sizeof(filepath), "%s/shared1/%08x.app", installpath, (unsigned int)content_map_size);
 		}
 		else {
 			// private content
@@ -419,6 +420,16 @@ bool Wad::InstallContents(const char *installpath)
 				ShowError(tr("File read/write error."));
 			return false;
 		}
+
+		if(content->type == 0x8001) {
+			// shared content installed ok. It's time to update content.map
+			int result = UpdateContentMap(installpath, content, filepath); 
+			if(result == 1) // exists already, skip file
+				continue;
+
+			else if(result < 0) // failure
+				return false;
+		}
 	}
 
 	return true;
@@ -481,8 +492,6 @@ int Wad::UpdateContentMap(const char *installpath, tmd_content *content, char *f
 	snprintf(filepath, 1024, "%s/shared1/content.map", installpath);
 	if(!WriteFile(filepath, content_map, content_map_size * sizeof(map_entry_t)))
 		return -1;
-
-	snprintf(filepath, 1024, "%s/shared1/%08x.app", installpath, (unsigned int)next_entry);
 
 	return 0;
 }

--- a/source/wad/wad.h
+++ b/source/wad/wad.h
@@ -49,6 +49,7 @@ public:
 private:
 	bool InstallContents(const char *installpath);
 	int CheckContentMap(const char *installpath, tmd_content *content, char *filepath);
+	int UpdateContentMap(const char *installpath, tmd_content *content, char *filepath);
 	bool WriteFile(const char *filepath, u8 *buffer, u32 len);
 	bool SetTitleUID(const char *intallpath, const u64 &tid);
 


### PR DESCRIPTION
This PR contains some fixes to problems I encountered when using USBLGX:

Emunand related:
- No more black animation banners due to emunand path+name being too large.
- Emunand WAD manager now installs wad's shared content. If this shared content is not previously installed in the Emunand, weird behaviour will result during loading (black screen, corrupted memory errors, ...)  or when exiting (errors opening the Operations Manual, freeze when exiting, ...). This fix is already included  in my previous [PR](https://github.com/wiidev/usbloadergx/pull/39).
Other:
- Minimize probability of a DSI Exception if you move to any screen (game settings, configuration) before the USB free space is shown in the main screen. It is probably more a bypass than a definitive fix to the race condition between the async thread that computes the HD free space and the menu manager when deletes the current screen to move to a new one.
- Initial USBLGX configuration file does uses  non-SSL URL to get custom banners. This is already advised in the Wii Hacks Guide. No change if the config file is already generated.

Each fix has is own commit. Any comment / code change proposal will be welcome.