### PR TITLE
vWii Channel view fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ usbloader_gx/
 /source/svnrev.c
 /usbloader_gx.zip
 /wiiload
+/output

--- a/source/SystemMenu/SystemMenuResources.cpp
+++ b/source/SystemMenu/SystemMenuResources.cpp
@@ -56,9 +56,16 @@ bool SystemMenuResources::Init()
 	// determine resource cid
 	u16 idx = 0xffff;
 	tmd_content *contents = TMD_CONTENTS( p_tmd );
+
+	// Priiloader moves some system resources that we rely on from index 1 to index 9.
+	// In doing this it creates a 10th index (9) to contain the moved resources.
+	// If priiloader is installed, we need to look for content at index 9 instead of index 1.
+	bool hasVWiiPriiloader = p_tmd->num_contents == 10;
+	u16 targetIndex = hasVWiiPriiloader ? 9 : 1;
+
 	for( u16 i = 0; i < p_tmd->num_contents; i++ )
 	{
-		if( contents[ i ].index == 1 )
+		if( contents[ i ].index == targetIndex )
 		{
 			idx = i;
 			break;


### PR DESCRIPTION
This fixes isssues with the vWii channel view. 

We determine if priiloader + vWii is in use by checking the number of entries in the tmd. If its 10, we're on vWii with priiloader and need to use index 9 for the system resources.

Assuming @wiidev doesn't come back any time soon, I've [created a release of this content in my fork](https://github.com/Jacoby6000/usbloadergx/releases/tag/v3.0-1282).  I plan to merge some of the pending PRs here in to my releases over time, assuming the authors are ok with it.

Edit: Cleaned up this branch