### PR TITLE
Fix chinese.lang translations for technical terms

### DIFF
--- a/Languages/schinese.lang
+++ b/Languages/schinese.lang
@@ -580,10 +580,10 @@ msgid "Custom Paths"
 msgstr "自定义路径"
 
 msgid "Customs"
-msgstr "海关"
+msgstr "自定义"
 
 msgid "Customs/Original"
-msgstr "海关/原版"
+msgstr "自定义/原版"
 
 msgid "D Buttons"
 msgstr "D 按钮"
@@ -2555,7 +2555,7 @@ msgid "ms"
 msgstr "毫秒"
 
 msgid "of"
-msgstr "的"
+msgstr "自"
 
 msgid "seconds left"
 msgstr "剩余秒数"

--- a/Languages/tchinese.lang
+++ b/Languages/tchinese.lang
@@ -17,14 +17,14 @@ msgid " could not be downloaded."
 msgstr " 無法下載。"
 
 msgid " has been saved, but you might need to edit some cheats from a computer."
-msgstr " 已保存，但您可能需要從電腦編輯一些作弊碼。"
+msgstr " 已儲存，但您可能需要從電腦編輯一些作弊碼。"
 
 msgid " is not on the server."
 msgstr " 不在伺服器上。"
 
 #, c-format
 msgid "%i WAD file(s) not processed!"
-msgstr "%i 個WAD文件未處理！"
+msgstr "%i 個WAD檔案未處理！"
 
 #, c-format
 msgid "%i WAD found."
@@ -32,7 +32,7 @@ msgstr "找到 %i 個WAD。"
 
 #, c-format
 msgid "%i files not found on the server!"
-msgstr "伺服器上未找到 %i 個文件！"
+msgstr "伺服器上未找到 %i 個檔案！"
 
 #, c-format
 msgid "%s only accepts GameCube backups in ISO format."
@@ -40,7 +40,7 @@ msgstr "%s 只接受ISO格式的GameCube備份。"
 
 #, c-format
 msgid "%s requires AHB access! Please launch USB Loader GX from HBC or from an updated channel or forwarder."
-msgstr "%s 需要AHB訪問！請從HBC或更新的頻道或轉發器啟動USB Loader GX。"
+msgstr "%s 需要AHB存取！請從HBC或更新的頻道或轉發器啟動USB Loader GX。"
 
 msgid "--==       Devolution"
 msgstr "--==       Devolution"
@@ -139,13 +139,13 @@ msgid "All"
 msgstr "全部"
 
 msgid "All Partitions"
-msgstr "所有分區"
+msgstr "所有分割區"
 
 msgid "All WAD files processed successfully."
-msgstr "所有WAD文件處理成功。"
+msgstr "所有WAD檔案處理成功。"
 
 msgid "All files extracted."
-msgstr "所有文件已提取。"
+msgstr "所有檔案已擷取。"
 
 msgid "All images downloaded successfully."
 msgstr "所有圖片下載成功。"
@@ -160,7 +160,7 @@ msgid "Alternate DOL"
 msgstr "替代DOL"
 
 msgid "An example file was created here:"
-msgstr "示例文件已在此處創建："
+msgstr "範例檔案已在此處建立："
 
 msgid "Animation Start"
 msgstr "動畫開始"
@@ -184,7 +184,7 @@ msgid "Are you sure you want to delete this category?"
 msgstr "您確定要刪除此類別嗎？"
 
 msgid "Are you sure you want to import game categories from WiiTDB?"
-msgstr "您確定要從WiiTDB導入遊戲類別嗎？"
+msgstr "您確定要從WiiTDB匯入遊戲類別嗎？"
 
 msgid "Are you sure you want to lock USB Loader GX?"
 msgstr "您確定要鎖定USB Loader GX嗎？"
@@ -202,7 +202,7 @@ msgid "Ask"
 msgstr "詢問"
 
 msgid "Aspect Ratio"
-msgstr "縱橫比"
+msgstr "長寬比"
 
 msgid "Attention!"
 msgstr "注意！"
@@ -223,28 +223,28 @@ msgid "Auto Boot"
 msgstr "自動啟動"
 
 msgid "AutoInit Network"
-msgstr "自動初始化網絡"
+msgstr "自動初始化網路"
 
 msgid "Autoboot Discs"
-msgstr "自動啟動光盤"
+msgstr "自動啟動光碟"
 
 msgid "Autoboot Discs Delay"
-msgstr "自動啟動光盤延遲"
+msgstr "自動啟動光碟延遲"
 
 msgid "BBA Emulation"
 msgstr "BBA模擬"
 
 msgid "BBA Net Profile"
-msgstr "BBA網絡配置"
+msgstr "BBA網路設置"
 
 msgid "BCA Codes Path"
-msgstr "BCA代碼路徑"
+msgstr "BCA碼路徑"
 
 msgid "Back"
 msgstr "返回"
 
 msgid "Back to HBC or Wii Menu"
-msgstr "返回HBC或Wii菜單"
+msgstr "返回HBC或Wii選單"
 
 msgid "Background Music"
 msgstr "背景音樂"
@@ -256,7 +256,7 @@ msgid "Banner On Channels"
 msgstr "頻道上的橫幅"
 
 msgid "Banner Settings"
-msgstr "橫幅設置"
+msgstr "橫幅設定"
 
 msgid "Banner grid layout is only available with AHBPROT! Please consider installing new HBC version."
 msgstr "橫幅網格佈局僅在AHBPROT下可用！請考慮安裝新版本的HBC。"
@@ -268,85 +268,85 @@ msgid "Big thanks to:"
 msgstr "特別感謝："
 
 msgid "Block Banner Settings"
-msgstr "阻止橫幅設置"
+msgstr "阻擋橫幅設定"
 
 msgid "Block Categories Menu"
-msgstr "阻止類別菜單"
+msgstr "阻擋類別選單"
 
 msgid "Block Categories Modify"
-msgstr "阻止修改類別"
+msgstr "阻擋修改類別"
 
 msgid "Block Cover Downloads"
-msgstr "阻止封面下載"
+msgstr "阻擋封面下載"
 
 msgid "Block Custom Paths"
-msgstr "阻止自定義路徑"
+msgstr "阻擋自訂路徑"
 
 msgid "Block GUI Settings"
-msgstr "阻止GUI設置"
+msgstr "阻擋GUI設定"
 
 msgid "Block Game Install"
-msgstr "阻止遊戲安裝"
+msgstr "阻擋遊戲安裝"
 
 msgid "Block Game Settings"
-msgstr "阻止遊戲設置"
+msgstr "阻擋遊戲設定"
 
 msgid "Block Game Sources Button"
-msgstr "阻止遊戲來源按鈕"
+msgstr "阻擋遊戲來源按鈕"
 
 msgid "Block Game Type Button"
-msgstr "阻止遊戲類型按鈕"
+msgstr "阻擋遊戲類型按鈕"
 
 msgid "Block Global Settings"
-msgstr "阻止全局設置"
+msgstr "阻擋全域設定"
 
 msgid "Block HBC Menu"
-msgstr "阻止HBC菜單"
+msgstr "阻擋HBC選單"
 
 msgid "Block HBC Title Launcher"
-msgstr "阻止HBC標題啟動器"
+msgstr "阻擋HBC標題啟動器"
 
 msgid "Block Hard Drive Settings"
-msgstr "阻止硬盤設置"
+msgstr "阻擋硬碟設定"
 
 msgid "Block IOS Reload"
-msgstr "阻止IOS重載"
+msgstr "阻擋IOS重載"
 
 msgid "Block Loader Layout Button"
-msgstr "阻止加載器佈局按鈕"
+msgstr "阻擋載入器佈局按鈕"
 
 msgid "Block Loader Settings"
-msgstr "阻止加載器設置"
+msgstr "阻擋載入器設定"
 
 msgid "Block Miscellaneous Settings"
-msgstr "阻止雜項設置"
+msgstr "阻擋雜項設定"
 
 msgid "Block Parental Settings"
-msgstr "阻止家長設置"
+msgstr "阻擋家長設定"
 
 msgid "Block Priiloader Override"
-msgstr "阻止Priiloader覆蓋"
+msgstr "阻擋Priiloader覆蓋"
 
 msgid "Block Reset Settings"
-msgstr "阻止重置設置"
+msgstr "阻擋重置設定"
 
 msgid "Block SD Card Mode Button"
-msgstr "阻止SD卡模式按鈕"
+msgstr "阻擋SD卡模式按鈕"
 
 msgid "Block Sound Settings"
-msgstr "阻止聲音設置"
+msgstr "阻擋聲音設定"
 
 msgid "Block Theme Menu"
-msgstr "阻止主題菜單"
+msgstr "阻擋主題選單"
 
 msgid "Block Update Menu"
-msgstr "阻止更新菜單"
+msgstr "阻擋更新選單"
 
 msgid "Boot Content"
 msgstr "啟動內容"
 
 msgid "Boot Neek System Menu"
-msgstr "啟動Neek系統菜單"
+msgstr "啟動Neek系統選單"
 
 msgid "Boot?"
 msgstr "啟動？"
@@ -355,50 +355,50 @@ msgid "Both"
 msgstr "兩者"
 
 msgid "Both Ports"
-msgstr "兩個端口"
+msgstr "兩個埠"
 
 msgid "CC Rumble"
 msgstr "CC震動"
 
 msgid "Cache BNR Files"
-msgstr "緩存BNR文件"
+msgstr "快取BNR檔案"
 
 msgid "Cache BNR Files Path"
-msgstr "緩存BNR文件路徑"
+msgstr "快取BNR檔案路徑"
 
 msgid "Cache Path"
-msgstr "緩存路徑"
+msgstr "快取路徑"
 
 msgid "Cache Titles"
-msgstr "緩存標題"
+msgstr "快取標題"
 
 msgid "Can't be formatted"
 msgstr "無法格式化"
 
 msgid "Can't create directory"
-msgstr "無法創建目錄"
+msgstr "無法建立目錄"
 
 #, c-format
 msgid "Can't create file: %s"
-msgstr "無法創建文件：%s"
+msgstr "無法建立檔案：%s"
 
 msgid "Can't delete:"
 msgstr "無法刪除："
 
 msgid "Can't mount or unknown disc format."
-msgstr "無法掛載或未知光盤格式。"
+msgstr "無法掛載或未知光碟格式。"
 
 #, c-format
 msgid "Can't open file for write: %s"
-msgstr "無法打開文件進行寫入：%s"
+msgstr "無法開啟檔案進行寫入：%s"
 
 #, c-format
 msgid "Can't open file: %s"
-msgstr "無法打開文件：%s"
+msgstr "無法開啟檔案：%s"
 
 #, c-format
 msgid "Can't read file: %s"
-msgstr "無法讀取文件：%s"
+msgstr "無法讀取檔案：%s"
 
 msgid "Can't write to destination."
 msgstr "無法寫入目標位置。"
@@ -425,7 +425,7 @@ msgid "Channels"
 msgstr "頻道"
 
 msgid "Cheat file is blank"
-msgstr "作弊文件為空"
+msgstr "作弊檔案為空"
 
 msgid "Clear"
 msgstr "清除"
@@ -434,7 +434,7 @@ msgid "Click to download covers"
 msgstr "點擊下載封面"
 
 msgid "Click to view information"
-msgstr "點擊查看信息"
+msgstr "點擊查看資訊"
 
 msgid "Clock"
 msgstr "時鐘"
@@ -459,7 +459,7 @@ msgid "Console"
 msgstr "控制台"
 
 msgid "Console Default"
-msgstr "控制台默認"
+msgstr "控制台預設"
 
 msgid "Console Locked"
 msgstr "控制台已鎖定"
@@ -495,50 +495,50 @@ msgid "Copying GC game..."
 msgstr "正在複製GC遊戲..."
 
 msgid "Copying files..."
-msgstr "正在複製文件..."
+msgstr "正在複製檔案..."
 
 msgid "Correct Password"
 msgstr "正確密碼"
 
 msgid "Could Not Open Disc"
-msgstr "無法打開光盤"
+msgstr "無法開啟光碟"
 
 msgid "Could not create GCT file"
-msgstr "無法創建GCT文件"
+msgstr "無法建立GCT檔案"
 
 #, c-format
 msgid "Could not create path: %s"
-msgstr "無法創建路徑：%s"
+msgstr "無法建立路徑：%s"
 
 msgid "Could not extract files for:"
-msgstr "無法提取文件："
+msgstr "無法擷取檔案："
 
 msgid "Could not find info for this game in the wiitdb.xml."
-msgstr "在wiitdb.xml中找不到此遊戲的信息。"
+msgstr "在wiitdb.xml中找不到此遊戲的資訊。"
 
 msgid "Could not get free device space for game."
-msgstr "無法獲取遊戲的可用設備空間。"
+msgstr "無法獲取遊戲的可用裝置空間。"
 
 msgid "Could not initialize DIP module!"
-msgstr "無法初始化DIP模塊！"
+msgstr "無法初始化DIP模組！"
 
 msgid "Could not initialize network. Timed out!"
-msgstr "無法初始化網絡。超時！"
+msgstr "無法初始化網路。超時！"
 
 msgid "Could not open disc"
-msgstr "無法打開光盤"
+msgstr "無法開啟光碟"
 
 msgid "Could not open the WiiTDB.xml file."
-msgstr "無法打開WiiTDB.xml文件。"
+msgstr "無法開啟WiiTDB.xml檔案。"
 
 msgid "Could not open wiitdb.xml."
-msgstr "無法打開wiitdb.xml。"
+msgstr "無法開啟wiitdb.xml。"
 
 msgid "Could not save."
-msgstr "無法保存。"
+msgstr "無法儲存。"
 
 msgid "Could not write file."
-msgstr "無法寫入文件。"
+msgstr "無法寫入檔案。"
 
 msgid "Could not write to:"
 msgstr "無法寫入："
@@ -550,7 +550,7 @@ msgid "Cover Download"
 msgstr "封面下載"
 
 msgid "Create"
-msgstr "創建"
+msgstr "建立"
 
 msgid "Credits"
 msgstr "製作人員"
@@ -559,31 +559,31 @@ msgid "Crop Overscan"
 msgstr "裁剪過掃"
 
 msgid "Current neek files are not neek2o. Game autoboot disabled."
-msgstr "當前的neek文件不是neek2o。遊戲自動啟動已禁用。"
+msgstr "當前的neek檔案不是neek2o。遊戲自動啟動已禁用。"
 
 msgid "Custom"
-msgstr "自定義"
+msgstr "自訂"
 
 msgid "Custom Address"
-msgstr "自定義地址"
+msgstr "自訂地址"
 
 msgid "Custom Banners"
-msgstr "自定義橫幅"
+msgstr "自訂橫幅"
 
 msgid "Custom Game IOS"
-msgstr "自定義遊戲IOS"
+msgstr "自訂遊戲IOS"
 
 msgid "Custom Games IOS"
-msgstr "自定義遊戲IOS"
+msgstr "自訂遊戲IOS"
 
 msgid "Custom Paths"
-msgstr "自定義路徑"
+msgstr "自訂路徑"
 
 msgid "Customs"
-msgstr "自定義"
+msgstr "自訂"
 
 msgid "Customs/Original"
-msgstr "自定義/原始"
+msgstr "自訂/原始"
 
 msgid "D Buttons"
 msgstr "D按鈕"
@@ -592,31 +592,31 @@ msgid "DOL Path"
 msgstr "DOL路徑"
 
 msgid "Debug"
-msgstr "調試"
+msgstr "除錯"
 
 msgid "Debug Wait"
-msgstr "調試等待"
+msgstr "除錯等待"
 
 msgid "Debugger Paused Start"
-msgstr "調試器暫停啟動"
+msgstr "除錯器暫停啟動"
 
 msgid "Dec"
 msgstr "十二月"
 
 msgid "Default"
-msgstr "默認"
+msgstr "預設"
 
 msgid "Default Settings"
-msgstr "默認設置"
+msgstr "預設設定"
 
 msgid "Deflicker Filter"
-msgstr "去閃濾波器"
+msgstr "去閃爍濾波器"
 
 msgid "Delete"
 msgstr "刪除"
 
 msgid "Delete Cached Banner"
-msgstr "刪除緩存橫幅"
+msgstr "刪除快取橫幅"
 
 msgid "Delete Cheat GCT"
 msgstr "刪除作弊GCT"
@@ -628,10 +628,10 @@ msgid "Delete Cover Artwork"
 msgstr "刪除封面藝術"
 
 msgid "Delete Disc Artwork"
-msgstr "刪除光盤藝術"
+msgstr "刪除光碟藝術"
 
 msgid "Delete EmuNAND Saves"
-msgstr "刪除EmuNAND保存"
+msgstr "刪除EmuNAND存檔"
 
 msgid "Delete category"
 msgstr "刪除類別"
@@ -640,13 +640,13 @@ msgid "Deleting directories..."
 msgstr "正在刪除目錄..."
 
 msgid "Deleting files..."
-msgstr "正在刪除文件..."
+msgstr "正在刪除檔案..."
 
 msgid "Design:"
 msgstr "設計："
 
 msgid "Details"
-msgstr "詳細信息"
+msgstr "詳細資訊"
 
 msgid "Developed by"
 msgstr "開發者"
@@ -658,10 +658,10 @@ msgid "Devolution"
 msgstr "Devolution"
 
 msgid "Devolution Loader Path"
-msgstr "Devolution加載器路徑"
+msgstr "Devolution載入器路徑"
 
 msgid "Devolution's loader.bin file can't be loaded."
-msgstr "無法加載Devolution的loader.bin文件。"
+msgstr "無法載入Devolution的loader.bin檔案。"
 
 msgid "Directory does not exist!"
 msgstr "目錄不存在！"
@@ -676,43 +676,43 @@ msgid "Disable Wiimote Speaker"
 msgstr "禁用Wiimote揚聲器"
 
 msgid "Disc"
-msgstr "光盤"
+msgstr "光碟"
 
 msgid "Disc 1"
-msgstr "光盤1"
+msgstr "光碟1"
 
 msgid "Disc 2"
-msgstr "光盤2"
+msgstr "光碟2"
 
 msgid "Disc Artwork"
-msgstr "光盤藝術"
+msgstr "光碟藝術"
 
 msgid "Disc Artwork Download"
-msgstr "光盤藝術下載"
+msgstr "光碟藝術下載"
 
 msgid "Disc Artwork Path"
-msgstr "光盤藝術路徑"
+msgstr "光碟藝術路徑"
 
 msgid "Disc Default"
-msgstr "光盤默認"
+msgstr "光碟預設"
 
 msgid "Disc Insert Detected"
-msgstr "檢測到光盤插入"
+msgstr "檢測到光碟插入"
 
 msgid "Disc Read Delay"
-msgstr "光盤讀取延遲"
+msgstr "光碟讀取延遲"
 
 msgid "Disc read error."
-msgstr "光盤讀取錯誤。"
+msgstr "光碟讀取錯誤。"
 
 msgid "Disc-Select Prompt"
-msgstr "光盤選擇提示"
+msgstr "光碟選擇提示"
 
 msgid "Disc2 needs to be installed in uncompressed format to work with DM(L) v2.6+, are you sure you want to install in compressed format?"
 msgstr "Disc2需要以未壓縮格式安裝才能與DM(L) v2.6+一起使用，您確定要以壓縮格式安裝嗎？"
 
 msgid "DiskFlip"
-msgstr "磁盤翻轉"
+msgstr "光碟翻轉"
 
 msgid "Display"
 msgstr "顯示"
@@ -745,7 +745,7 @@ msgid "Displaying Wii games"
 msgstr "顯示Wii遊戲"
 
 msgid "Displaying a custom selection"
-msgstr "顯示自定義選擇"
+msgstr "顯示自訂選擇"
 
 msgid "Displaying as a carousel"
 msgstr "顯示為旋轉木馬"
@@ -763,7 +763,7 @@ msgid "Do You Want To Change Language?"
 msgstr "您想更改語言嗎？"
 
 msgid "Do you want to apply this theme?"
-msgstr "您想應用此主題嗎？"
+msgstr "您想套用此主題嗎？"
 
 msgid "Do you want to continue with next game?"
 msgstr "您想繼續下一個遊戲嗎？"
@@ -781,10 +781,10 @@ msgid "Do you want to discard changes?"
 msgstr "您想放棄更改嗎？"
 
 msgid "Do you want to extract all the save games?"
-msgstr "您想提取所有存檔嗎？"
+msgstr "您想擷取所有存檔嗎？"
 
 msgid "Do you want to extract the save game?"
-msgstr "您想提取存檔嗎？"
+msgstr "您想擷取存檔嗎？"
 
 msgid "Do you want to format:"
 msgstr "您想格式化："
@@ -793,13 +793,13 @@ msgid "Do you want to install selected games?"
 msgstr "您想安裝選定的遊戲嗎？"
 
 msgid "Do you want to load the default theme?"
-msgstr "您想加載默認主題嗎？"
+msgstr "您想載入預設主題嗎？"
 
 msgid "Do you want to move the file(s)? Any existing ones will be deleted!"
-msgstr "您想移動文件嗎？任何現有的文件都將被刪除！"
+msgstr "您想移動檔案嗎？任何現有的檔案都將被刪除！"
 
 msgid "Do you want to re-init network?"
-msgstr "您想重新初始化網絡嗎？"
+msgstr "您想重新初始化網路嗎？"
 
 msgid "Do you want to start the game now?"
 msgstr "您想現在開始遊戲嗎？"
@@ -808,17 +808,17 @@ msgid "Do you want to use cheats?"
 msgstr "您想使用作弊嗎？"
 
 msgid "Do you wish to update/download all language files?"
-msgstr "您想更新/下載所有語言文件嗎？"
+msgstr "您想更新/下載所有語言檔案嗎？"
 
 msgid "Dol Video Patch"
-msgstr "Dol視頻補丁"
+msgstr "Dol影像補丁"
 
 msgid "Download"
 msgstr "下載"
 
 #, c-format
 msgid "Download %i missing files?"
-msgstr "下載%i個缺失的文件？"
+msgstr "下載%i個缺失的檔案？"
 
 msgid "Download Now"
 msgstr "立即下載"
@@ -830,28 +830,28 @@ msgid "Downloading 3D Covers"
 msgstr "正在下載3D封面"
 
 msgid "Downloading Custom Banners"
-msgstr "正在下載自定義橫幅"
+msgstr "正在下載自訂橫幅"
 
 msgid "Downloading Custom Disc Artwork"
-msgstr "正在下載自定義光盤藝術"
+msgstr "正在下載自訂光碟藝術"
 
 msgid "Downloading Flat Covers"
 msgstr "正在下載平面封面"
 
 msgid "Downloading Full HQ Covers"
-msgstr "正在下載全高清封面"
+msgstr "正在下載全高畫質封面"
 
 msgid "Downloading Full LQ Covers"
-msgstr "正在下載全低清封面"
+msgstr "正在下載全低畫質封面"
 
 msgid "Downloading Original Disc Artwork"
-msgstr "正在下載原始光盤藝術"
+msgstr "正在下載原始光碟藝術"
 
 msgid "Downloading file..."
-msgstr "正在下載文件..."
+msgstr "正在下載檔案..."
 
 msgid "Dump NAND to EmuNAND"
-msgstr "將NAND轉儲到EmuNAND"
+msgstr "將NAND傾印到EmuNAND"
 
 msgid "During zoom"
 msgstr "縮放期間"
@@ -869,10 +869,10 @@ msgid "EmuNAND Channel Path"
 msgstr "EmuNAND頻道路徑"
 
 msgid "EmuNAND Save Mode"
-msgstr "EmuNAND 保存模式"
+msgstr "EmuNAND 存檔模式"
 
 msgid "EmuNAND Save Path"
-msgstr "EmuNAND 保存路徑"
+msgstr "EmuNAND 存檔路徑"
 
 msgid "EmuNAND WAD Manager"
 msgstr "EmuNAND WAD 管理器"
@@ -890,32 +890,32 @@ msgid "Enter Path"
 msgstr "輸入路徑"
 
 msgid "Error Reading Disc"
-msgstr "讀取光盤錯誤"
+msgstr "讀取光碟錯誤"
 
 #, c-format
 msgid "Error creating path: %s"
-msgstr "創建路徑錯誤：%s"
+msgstr "建立路徑錯誤：%s"
 
 msgid "Error opening downloaded file"
-msgstr "打開下載文件錯誤"
+msgstr "開啟下載檔案錯誤"
 
 msgid "Error reading disc"
-msgstr "讀取光盤錯誤"
+msgstr "讀取光碟錯誤"
 
 msgid "Error while downloading file"
-msgstr "下載文件時出錯"
+msgstr "下載檔案時出錯"
 
 msgid "Error while opening the zip."
-msgstr "打開壓縮文件時出錯"
+msgstr "開啟壓縮檔案時出錯"
 
 msgid "Error while transferring data."
-msgstr "傳輸數據時出錯"
+msgstr "傳輸資料時出錯"
 
 msgid "Error while updating USB Loader GX."
 msgstr "更新 USB Loader GX 時出錯"
 
 msgid "Error writing the data."
-msgstr "寫入數據時出錯"
+msgstr "寫入資料時出錯"
 
 msgid "Error:"
 msgstr "錯誤："
@@ -936,34 +936,34 @@ msgid "Exit to where?"
 msgstr "退出到哪裡？"
 
 msgid "Export All Saves to EmuNAND"
-msgstr "導出所有保存到 EmuNAND"
+msgstr "匯出所有存檔到 EmuNAND"
 
 msgid "Export Miis to EmuNAND"
-msgstr "導出 Miis 到 EmuNAND"
+msgstr "匯出 Miis 到 EmuNAND"
 
 msgid "Export SYSCONF to EmuNAND"
-msgstr "導出 SYSCONF 到 EmuNAND"
+msgstr "匯出 SYSCONF 到 EmuNAND"
 
 msgid "Extract Miis to the EmuNAND?"
-msgstr "提取 Miis 到 EmuNAND？"
+msgstr "擷取 Miis 到 EmuNAND？"
 
 msgid "Extract SYSCONF to the EmuNAND?"
-msgstr "提取 SYSCONF 到 EmuNAND？"
+msgstr "擷取 SYSCONF 到 EmuNAND？"
 
 msgid "Extract Save to EmuNAND"
-msgstr "提取保存到 EmuNAND"
+msgstr "擷取存檔到 EmuNAND"
 
 msgid "Extracting NAND files:"
-msgstr "提取 NAND 文件："
+msgstr "擷取 NAND 檔案："
 
 msgid "Extracting file:"
-msgstr "提取文件："
+msgstr "擷取檔案："
 
 msgid "Extracting files..."
-msgstr "正在提取文件..."
+msgstr "正在擷取檔案..."
 
 msgid "Extracting files:"
-msgstr "提取文件："
+msgstr "擷取檔案："
 
 msgid "F-Zero AX"
 msgstr "F-Zero AX"
@@ -972,19 +972,19 @@ msgid "Failed"
 msgstr "失敗"
 
 msgid "Failed copying file"
-msgstr "複製文件失敗"
+msgstr "複製檔案失敗"
 
 msgid "Failed formatting"
 msgstr "格式化失敗"
 
 msgid "Failed to extract all files. Savegame might not exist."
-msgstr "提取所有文件失敗。保存遊戲可能不存在。"
+msgstr "擷取所有檔案失敗。存檔可能不存在。"
 
 msgid "Failed to initialize the USB storage device."
-msgstr "初始化 USB 存儲設備失敗。"
+msgstr "初始化 USB 儲存裝置失敗。"
 
 msgid "Failed to open partition"
-msgstr "打開分區失敗"
+msgstr "開啟分割區失敗"
 
 msgid "Failed to read WAD header."
 msgstr "讀取 WAD 頭失敗。"
@@ -993,7 +993,7 @@ msgid "Failed to read ticket."
 msgstr "讀取票據失敗。"
 
 msgid "Failed to read tmd file."
-msgstr "讀取 tmd 文件失敗。"
+msgstr "讀取 tmd 檔案失敗。"
 
 msgid "Failed updating"
 msgstr "更新失敗"
@@ -1005,16 +1005,16 @@ msgid "Feb"
 msgstr "二月"
 
 msgid "File"
-msgstr "文件"
+msgstr "檔案"
 
 msgid "File not found."
-msgstr "文件未找到。"
+msgstr "檔案未找到。"
 
 msgid "File read/write error."
-msgstr "文件讀/寫錯誤。"
+msgstr "檔案讀/寫錯誤。"
 
 msgid "Files extracted successfully."
-msgstr "文件提取成功。"
+msgstr "檔案擷取成功。"
 
 msgid "Flat Covers"
 msgstr "平面封面"
@@ -1023,7 +1023,7 @@ msgid "Flip-X"
 msgstr "翻轉-X"
 
 msgid "Folder"
-msgstr "文件夾"
+msgstr "資料夾"
 
 msgid "Font Scale Factor"
 msgstr "字體縮放因子"
@@ -1050,7 +1050,7 @@ msgid "Force PAL60"
 msgstr "強制 PAL60"
 
 msgid "Force Widescreen"
-msgstr "強制寬屏"
+msgstr "強制寬螢幕"
 
 msgid "Format"
 msgstr "格式化"
@@ -1101,7 +1101,7 @@ msgid "Full Covers Download"
 msgstr "全封面下載"
 
 msgid "Full Menu"
-msgstr "全菜單"
+msgstr "全選單"
 
 msgid "Full shutdown"
 msgstr "完全關機"
@@ -1122,13 +1122,13 @@ msgid "GC Install Compressed"
 msgstr "GC 安裝壓縮"
 
 msgid "GCT Cheat Codes Path"
-msgstr "GCT 作弊代碼路徑"
+msgstr "GCT 作弊碼路徑"
 
 msgid "GCT File created"
-msgstr "GCT 文件已創建"
+msgstr "GCT 檔案已建立"
 
 msgid "GUI Settings"
-msgstr "GUI 設置"
+msgstr "GUI 設定"
 
 msgid "GXDraw"
 msgstr "GX繪製"
@@ -1149,7 +1149,7 @@ msgid "Game Language"
 msgstr "遊戲語言"
 
 msgid "Game Load"
-msgstr "遊戲加載"
+msgstr "遊戲載入"
 
 msgid "Game Lock"
 msgstr "遊戲鎖定"
@@ -1176,7 +1176,7 @@ msgid "Game Window Mode"
 msgstr "遊戲窗口模式"
 
 msgid "Game/Install Partition"
-msgstr "遊戲/安裝分區"
+msgstr "遊戲/安裝分割區"
 
 msgid "GameCube"
 msgstr "GameCube"
@@ -1188,7 +1188,7 @@ msgid "GameCube Games Delete"
 msgstr "刪除GameCube遊戲"
 
 msgid "GameCube Install Menu"
-msgstr "GameCube安裝菜單"
+msgstr "GameCube安裝選單"
 
 msgid "GameCube Mode"
 msgstr "GameCube模式"
@@ -1218,31 +1218,31 @@ msgid "German"
 msgstr "德語"
 
 msgid "Getting file list..."
-msgstr "獲取文件列表..."
+msgstr "獲取檔案列表..."
 
 msgid "Getting game folder size..."
-msgstr "獲取遊戲文件夾大小..."
+msgstr "獲取遊戲資料夾大小..."
 
 msgid "Global Settings"
-msgstr "全局設置"
+msgstr "全域設定"
 
 msgid "Grid Scroll Speed"
 msgstr "網格滾動速度"
 
 msgid "HOME Menu"
-msgstr "HOME菜單"
+msgstr "HOME選單"
 
 msgid "Hard Drive Settings"
-msgstr "硬盤設置"
+msgstr "硬碟設定"
 
 msgid "High Quality"
-msgstr "高質量"
+msgstr "高品質"
 
 msgid "High/Low"
 msgstr "高/低"
 
 msgid "Homebrew Apps Path"
-msgstr "Homebrew應用路徑"
+msgstr "Homebrew Apps 路徑"
 
 msgid "Homebrew Channel"
 msgstr "Homebrew頻道"
@@ -1260,36 +1260,36 @@ msgid "How to Shutdown?"
 msgstr "如何關機？"
 
 msgid "Import Categories"
-msgstr "導入類別"
+msgstr "匯入類別"
 
 msgid "Import operation successfully completed."
-msgstr "導入操作成功完成。"
+msgstr "匯入操作成功完成。"
 
 msgid "Importing categories"
-msgstr "正在導入類別"
+msgstr "正在匯入類別"
 
 #, c-format
 msgid "Incoming file %0.2fKB"
-msgstr "接收文件 %0.2fKB"
+msgstr "接收檔案 %0.2fKB"
 
 #, c-format
 msgid "Incoming file %0.2fMB"
-msgstr "接收文件 %0.2fMB"
+msgstr "接收檔案 %0.2fMB"
 
 msgid "Individual"
 msgstr "個人"
 
 msgid "Information"
-msgstr "信息"
+msgstr "資訊"
 
 msgid "Initializing Network"
-msgstr "初始化網絡"
+msgstr "初始化網路"
 
 msgid "Insert Disc"
-msgstr "插入光盤"
+msgstr "插入光碟"
 
 msgid "Insert a Wii or a GameCube disc!"
-msgstr "插入Wii或GameCube光盤！"
+msgstr "插入Wii或GameCube光碟！"
 
 msgid "Install"
 msgstr "安裝"
@@ -1307,7 +1307,7 @@ msgid "Install Finished"
 msgstr "安裝完成"
 
 msgid "Install Partitions"
-msgstr "安裝分區"
+msgstr "安裝分割區"
 
 msgid "Install a Game?"
 msgstr "安裝遊戲？"
@@ -1316,7 +1316,7 @@ msgid "Install a game"
 msgstr "安裝遊戲"
 
 msgid "Install error - Cleaning incomplete data."
-msgstr "安裝錯誤 - 清理不完整數據。"
+msgstr "安裝錯誤 - 清理不完整資料。"
 
 msgid "Installing Game:"
 msgstr "正在安裝遊戲："
@@ -1331,16 +1331,16 @@ msgid "Installing title..."
 msgstr "正在安裝標題..."
 
 msgid "Invalid IOS number entered. Number must be -1 for inherit or 200 - 255."
-msgstr "輸入的IOS號碼無效。號碼必須為-1繼承或200 - 255。"
+msgstr "輸入的IOS號碼無效。號碼必須為-1對應繼承或200 - 255。"
 
 msgid "Invalid WAD file."
-msgstr "無效的WAD文件。"
+msgstr "無效的WAD檔案。"
 
 msgid "It seems that you have some information that will be helpful to us. Please pass this information along to the DEV team."
-msgstr "看起來您有一些對我們有幫助的信息。請將這些信息傳遞給開發團隊。"
+msgstr "看起來您有一些對我們有幫助的資訊。請將這些資訊傳遞給開發團隊。"
 
 msgid "Italian"
-msgstr "意大利語"
+msgstr "義大利語"
 
 msgid "Jan"
 msgstr "一月"
@@ -1352,7 +1352,7 @@ msgid "Japanese Patch"
 msgstr "日語補丁"
 
 msgid "Joypad"
-msgstr "遊戲手柄"
+msgstr "遊戲手把"
 
 msgid "July"
 msgstr "七月"
@@ -1397,29 +1397,29 @@ msgid "List on game launch"
 msgstr "遊戲啟動時列出"
 
 msgid "Load"
-msgstr "加載"
+msgstr "載入"
 
 #, c-format
 msgid "Load file from: %s ?"
-msgstr "從%s加載文件？"
+msgstr "從%s載入檔案？"
 
 msgid "Load from SD/USB"
-msgstr "從SD/USB加載"
+msgstr "從SD/USB載入"
 
 msgid "Load this DOL as alternate DOL?"
-msgstr "將此DOL加載為替代DOL？"
+msgstr "將此DOL載入為替代DOL？"
 
 msgid "Loader Settings"
-msgstr "加載器設置"
+msgstr "載入器設定"
 
 msgid "Loaders IOS"
-msgstr "加載器IOS"
+msgstr "載入器IOS"
 
 msgid "Loading Standard Language."
-msgstr "加載標準語言。"
+msgstr "載入標準語言。"
 
 msgid "Loading standard music."
-msgstr "加載標準音樂。"
+msgstr "載入標準音樂。"
 
 msgid "Lock Console"
 msgstr "鎖定控制台"
@@ -1431,7 +1431,7 @@ msgid "Locked"
 msgstr "已鎖定"
 
 msgid "Log to file"
-msgstr "記錄到文件"
+msgstr "記錄到檔案"
 
 msgid "Loop Directory"
 msgstr "循環目錄"
@@ -1443,13 +1443,13 @@ msgid "Loop Sound"
 msgstr "循環聲音"
 
 msgid "Low Quality"
-msgstr "低質量"
+msgstr "低品質"
 
 msgid "Low/High"
 msgstr "低/高"
 
 msgid "MIOS (Default & Customs)"
-msgstr "MIOS（默認和自定義）"
+msgstr "MIOS（預設和自訂）"
 
 msgid "Main DOL"
 msgstr "主DOL"
@@ -1488,19 +1488,19 @@ msgid "Messageboard Update"
 msgstr "留言板更新"
 
 msgid "Miscellaneous Settings"
-msgstr "雜項設置"
+msgstr "雜項設定"
 
 msgid "Motion+ Video"
-msgstr "Motion+視頻"
+msgstr "Motion+影像"
 
 msgid "Mount DVD drive"
 msgstr "掛載DVD驅動器"
 
 msgid "Move File"
-msgstr "移動文件"
+msgstr "移動檔案"
 
 msgid "Multiple Partitions"
-msgstr "多個分區"
+msgstr "多個分割區"
 
 msgid "Music Loop Mode"
 msgstr "音樂循環模式"
@@ -1515,13 +1515,13 @@ msgid "NAND emulation is only available on d2x cIOS!"
 msgstr "NAND模擬僅適用於d2x cIOS！"
 
 msgid "NAND emulation only works on FAT/FAT32 partitions!"
-msgstr "NAND模擬僅適用於FAT/FAT32分區！"
+msgstr "NAND模擬僅適用於FAT/FAT32分割區！"
 
 msgid "NMM Mode"
 msgstr "NMM模式"
 
 msgid "Native Controller"
-msgstr "本地控制器"
+msgstr "原生控制器"
 
 msgid "Neek"
 msgstr "Neek"
@@ -1530,22 +1530,19 @@ msgid "Neek NAND path selection failed."
 msgstr "Neek NAND路徑選擇失敗。"
 
 msgid "Neek kernel file not found."
-msgstr "未找到Neek內核文件。"
+msgstr "未找到Neek內核檔案。"
 
 msgid "Neek kernel loading failed."
-msgstr "Neek內核加載失敗。"
+msgstr "Neek內核載入失敗。"
 
 msgid "Neek2o does not support 'EmuNAND Channel Path' on SD! Please setup Uneek2o instead."
-msgstr "Neek2o不支持SD上的'EmuNAND頻道路徑'！請改為設置Uneek2o。"
+msgstr "Neek2o不支援SD上的'EmuNAND頻道路徑'！請改為設定Uneek2o。"
 
 msgid "Neither"
 msgstr "都不是"
 
-msgid "Network is not initalized."
-msgstr "網絡未初始化。"
-
 msgid "Network is not initialized."
-msgstr "網絡未初始化。"
+msgstr "網路未初始化。"
 
 msgid "Next"
 msgstr "下一步"
@@ -1554,55 +1551,55 @@ msgid "Nintendont"
 msgstr "Nintendont"
 
 msgid "Nintendont Loader Path"
-msgstr "Nintendont加載器路徑"
+msgstr "Nintendont載入器路徑"
 
 msgid "No"
 msgstr "否"
 
 msgid "No Cheat file found"
-msgstr "未找到作弊文件"
+msgstr "未找到作弊檔案"
 
 msgid "No DOL file found on disc."
-msgstr "光盤上未找到DOL文件。"
+msgstr "光碟上未找到DOL檔案。"
 
 msgid "No Disc Inserted"
-msgstr "未插入光盤"
+msgstr "未插入光碟"
 
 msgid "No Disc+"
-msgstr "無光盤+"
+msgstr "無光碟+"
 
 msgid "No Splitting"
 msgstr "不分割"
 
 msgid "No WAD file found in this folder."
-msgstr "在此文件夾中未找到WAD文件。"
+msgstr "在此資料夾中未找到WAD檔案。"
 
 msgid "No WBFS or FAT/NTFS/EXT partition found"
-msgstr "未找到WBFS或FAT/NTFS/EXT分區"
+msgstr "未找到WBFS或FAT/NTFS/EXT分割區"
 
 msgid "No Wiinnertag.xml found in the config path. Do you want an example file created?"
-msgstr "在配置路徑中未找到Wiinnertag.xml。是否要創建示例文件？"
+msgstr "在設置路徑中未找到Wiinnertag.xml。是否要建立範例檔案？"
 
 msgid "No change"
 msgstr "無變化"
 
 msgid "No cheats were selected! Should the GCT file be deleted?"
-msgstr "未選擇任何作弊！是否應刪除GCT文件？"
+msgstr "未選擇任何作弊！是否要刪除GCT檔案？"
 
 msgid "No data could be read."
-msgstr "無法讀取數據。"
+msgstr "無法讀取資料。"
 
 msgid "No favorites selected."
 msgstr "未選擇收藏。"
 
 msgid "No files missing!"
-msgstr "沒有缺失的文件！"
+msgstr "沒有缺失的檔案！"
 
 msgid "No games found on the disc"
-msgstr "光盤上未找到遊戲"
+msgstr "光碟上未找到遊戲"
 
 msgid "No language files to update on your devices! Do you want to download new language files?"
-msgstr "您的設備上沒有要更新的語言文件！是否要下載新的語言文件？"
+msgstr "您的裝置上沒有需更新的語言檔案！是否要下載新的語言檔案？"
 
 msgid "No new updates."
 msgstr "沒有新更新。"
@@ -1626,25 +1623,25 @@ msgid "Not Initialized"
 msgstr "未初始化"
 
 msgid "Not a Wii or a GameCube Disc"
-msgstr "不是Wii或GameCube光盤"
+msgstr "不是Wii或GameCube光碟"
 
 msgid "Not enough free memory."
-msgstr "可用內存不足。"
+msgstr "可用記憶體不足。"
 
 msgid "Not enough free space on device."
-msgstr "設備上的可用空間不足。"
+msgstr "裝置上的可用空間不足。"
 
 msgid "Not enough memory for FST."
-msgstr "FST內存不足。"
+msgstr "FST記憶體不足。"
 
 msgid "Not enough memory."
-msgstr "內存不足。"
+msgstr "記憶體不足。"
 
 msgid "Not required"
 msgstr "不需要"
 
 msgid "Not set"
-msgstr "未設置"
+msgstr "未設定"
 
 msgid "Nothing selected to delete."
 msgstr "未選擇刪除任何內容。"
@@ -1659,7 +1656,7 @@ msgid "OFF"
 msgstr "關"
 
 msgid "OFF (Extended)"
-msgstr "關（擴展）"
+msgstr "關（擴充）"
 
 msgid "OFF (Safe)"
 msgstr "關（安全）"
@@ -1686,13 +1683,13 @@ msgid "OSReport"
 msgstr "OS報告"
 
 msgid "OSSleepThread"
-msgstr "OS睡眠線程"
+msgstr "OS睡眠執行緒"
 
 msgid "Ocarina"
 msgstr "Ocarina"
 
 msgid "Ocarina is not supported with neek2o yet. Launch game anyway?"
-msgstr "neek2o尚不支持Ocarina。仍然啟動遊戲嗎？"
+msgstr "neek2o尚不支援Ocarina。仍然啟動遊戲嗎？"
 
 msgid "Ocarina:"
 msgstr "Ocarina："
@@ -1716,7 +1713,7 @@ msgid "One Line B"
 msgstr "一行B"
 
 msgid "Only Game Partition"
-msgstr "僅遊戲分區"
+msgstr "僅遊戲分割區"
 
 msgid "Only for install"
 msgstr "僅供安裝"
@@ -1725,7 +1722,7 @@ msgid "Original"
 msgstr "原始"
 
 msgid "Original/Customs"
-msgstr "原始/自定義"
+msgstr "原始/自訂"
 
 msgid "PAD Hook"
 msgstr "PAD掛鉤"
@@ -1740,7 +1737,7 @@ msgid "Partial"
 msgstr "部分"
 
 msgid "Partition"
-msgstr "分區"
+msgstr "分割"
 
 msgid "Password"
 msgstr "密碼"
@@ -1749,10 +1746,10 @@ msgid "Password Changed"
 msgstr "密碼已更改"
 
 msgid "Password has been changed"
-msgstr "密碼已更改"
+msgstr "密碼已完成更改"
 
 msgid "Patch Country Strings"
-msgstr "補丁國家字符串"
+msgstr "補丁國家字串"
 
 msgid "Path Changed"
 msgstr "路徑已更改"
@@ -1806,7 +1803,7 @@ msgid "Process finished."
 msgstr "過程完成。"
 
 msgid "Progressive Patch"
-msgstr "漸進補丁"
+msgstr "循序式掃瞄補丁"
 
 msgid "Prompts Buttons"
 msgstr "提示按鈕"
@@ -1821,7 +1818,7 @@ msgid "Real NAND"
 msgstr "真實NAND"
 
 msgid "Receiving file from:"
-msgstr "接收文件來自："
+msgstr "接收檔案來自："
 
 msgid "Region Free"
 msgstr "區域自由"
@@ -1836,7 +1833,7 @@ msgid "Released"
 msgstr "發布"
 
 msgid "Reloading game list now, please wait..."
-msgstr "正在重新加載遊戲列表，請稍候..."
+msgstr "正在重新載入遊戲列表，請稍候..."
 
 msgid "Remember Last Game"
 msgstr "記住上次遊戲"
@@ -1851,25 +1848,25 @@ msgid "Remove update"
 msgstr "移除更新"
 
 msgid "Rename Game Title"
-msgstr "重命名遊戲標題"
+msgstr "重新命名遊戲標題"
 
 msgid "Rename category"
-msgstr "重命名類別"
+msgstr "重新命名類別"
 
 msgid "Resample to 48 kHz"
-msgstr "重採樣到48 kHz"
+msgstr "重新取樣到48 kHz"
 
 msgid "Reset"
 msgstr "重置"
 
 msgid "Reset All Game Settings"
-msgstr "重置所有遊戲設置"
+msgstr "重置所有遊戲設定"
 
 msgid "Reset BG Music"
 msgstr "重置背景音樂"
 
 msgid "Reset Cached Titles"
-msgstr "重置緩存標題"
+msgstr "重置快取標題"
 
 msgid "Reset Play Count"
 msgstr "重置播放次數"
@@ -1878,7 +1875,7 @@ msgid "Reset Wiimote Pairings"
 msgstr "重置 Wiimote 配對"
 
 msgid "Reset to default BGM?"
-msgstr "重置為默認背景音樂？"
+msgstr "重置為預設背景音樂？"
 
 msgid "Restarting..."
 msgstr "正在重啟..."
@@ -1890,13 +1887,13 @@ msgid "Return To"
 msgstr "返回到"
 
 msgid "Return to Wii Menu"
-msgstr "返回到Wii菜單"
+msgstr "返回到Wii選單"
 
 msgid "Right"
 msgstr "右"
 
 msgid "Rotating Disc"
-msgstr "旋轉光盤"
+msgstr "旋轉光碟"
 
 msgid "Round"
 msgstr "圓形"
@@ -1914,7 +1911,7 @@ msgid "SD Card Mode"
 msgstr "SD卡模式"
 
 msgid "SD Card could not be accessed."
-msgstr "無法訪問SD卡。"
+msgstr "無法存取SD卡。"
 
 msgid "SD GameCube Games Path"
 msgstr "SD GameCube遊戲路徑"
@@ -1929,22 +1926,22 @@ msgid "SFX Volume"
 msgstr "音效音量"
 
 msgid "Save"
-msgstr "保存"
+msgstr "存檔"
 
 msgid "Save Failed. No device inserted?"
-msgstr "保存失敗。未插入設備？"
+msgstr "存檔失敗。未插入裝置？"
 
 msgid "Save List"
-msgstr "保存列表"
+msgstr "存檔列表"
 
 msgid "Save Path"
-msgstr "保存路徑"
+msgstr "存檔路徑"
 
 msgid "Save game list to"
-msgstr "保存遊戲列表到"
+msgstr "儲存遊戲列表到"
 
 msgid "Saved"
-msgstr "已保存"
+msgstr "已存檔"
 
 msgid "Savegame might not exist for this game."
 msgstr "此遊戲可能不存在存檔。"
@@ -1953,7 +1950,7 @@ msgid "Screen Mode"
 msgstr "螢幕模式"
 
 msgid "Screensaver"
-msgstr "屏幕保護程序"
+msgstr "螢幕保護程式"
 
 msgid "Screenshot"
 msgstr "截圖"
@@ -1986,13 +1983,13 @@ msgid "Sept"
 msgstr "九月"
 
 msgid "Set search filter"
-msgstr "設置搜索過濾器"
+msgstr "設定搜索過濾器"
 
 msgid "Settings"
-msgstr "設置"
+msgstr "設定"
 
 msgid "Settings File"
-msgstr "設置文件"
+msgstr "設定檔案"
 
 msgid "Show Categories"
 msgstr "顯示類別"
@@ -2025,7 +2022,7 @@ msgid "Shutdown?"
 msgstr "關機？"
 
 msgid "Silent HOME Menu"
-msgstr "靜音HOME菜單"
+msgstr "靜音HOME選單"
 
 msgid "Skip Errors"
 msgstr "跳過錯誤"
@@ -2034,7 +2031,7 @@ msgid "Skip IPL"
 msgstr "跳過IPL"
 
 msgid "Sneek Video Patch"
-msgstr "Sneek視頻補丁"
+msgstr "Sneek影像補丁"
 
 msgid "Sorting alphabetically"
 msgstr "按字母順序排序"
@@ -2049,7 +2046,7 @@ msgid "Sorting by rank"
 msgstr "按排名排序"
 
 msgid "Sound Settings"
-msgstr "聲音設置"
+msgstr "聲音設定"
 
 msgid "Sound+BGM"
 msgstr "聲音+背景音樂"
@@ -2088,7 +2085,7 @@ msgid "Successfully Installed:"
 msgstr "成功安裝："
 
 msgid "Successfully Saved"
-msgstr "成功保存"
+msgstr "成功存檔"
 
 msgid "Successfully Updated"
 msgstr "成功更新"
@@ -2100,41 +2097,41 @@ msgid "Successfully deleted:"
 msgstr "成功刪除："
 
 msgid "System Default"
-msgstr "系統默認"
+msgstr "系統預設"
 
 msgid "System Proxy Settings"
-msgstr "系統代理設置"
+msgstr "系統代理設定"
 
 msgid "TChinese"
 msgstr "繁體中文"
 
 msgid "TXT Cheat Codes Path"
-msgstr "TXT作弊代碼路徑"
+msgstr "TXT作弊碼路徑"
 
 msgid "The Force Widescreen setting requires DIOS MIOS v2.1 or more. This setting will be ignored."
-msgstr "強制寬屏設置需要DIOS MIOS v2.1或更高版本。此設置將被忽略。"
+msgstr "強制寬螢幕設定需要DIOS MIOS v2.1或更高版本。此設定將被忽略。"
 
 msgid "The Miis will be extracted to your EmuNAND path and EmuNAND channel path. Attention: All existing files will be overwritten."
-msgstr "Miis將被提取到您的EmuNAND路徑和EmuNAND頻道路徑。注意：所有現有文件將被覆蓋。"
+msgstr "Miis將被擷取到您的EmuNAND路徑和EmuNAND頻道路徑。注意：所有現有檔案將被覆蓋。"
 
 msgid "The No Disc+ setting requires DIOS MIOS 2.2 update2. This setting will be ignored."
-msgstr "無光盤+設置需要DIOS MIOS 2.2更新2。此設置將被忽略。"
+msgstr "無光碟+設定需要DIOS MIOS 2.2更新2。此設定將被忽略。"
 
 msgid "The SYSCONF file will be extracted to your EmuNAND path and EmuNAND channel path. Attention: All existing files will be overwritten."
-msgstr "SYSCONF文件將被提取到您的EmuNAND路徑和EmuNAND頻道路徑。注意：所有現有文件將被覆蓋。"
+msgstr "SYSCONF檔案將被擷取到您的EmuNAND路徑和EmuNAND頻道路徑。注意：所有現有檔案將被覆蓋。"
 
 msgid "The WAD file was installed"
-msgstr "WAD文件已安裝"
+msgstr "WAD檔案已安裝"
 
 #, c-format
 msgid "The WAD installation failed with error %i"
 msgstr "WAD安裝失敗，錯誤%i"
 
 msgid "The entered directory does not exist. Would you like to create it?"
-msgstr "輸入的目錄不存在。您想創建它嗎？"
+msgstr "輸入的目錄不存在。您想建立它嗎？"
 
 msgid "The files will be extracted to your EmuNAND save and channel path. Attention: All existing files will be overwritten."
-msgstr "文件將被提取到您的EmuNAND保存和頻道路徑。注意：所有現有文件將被覆蓋。"
+msgstr "檔案將被擷取到您的EmuNAND存檔和頻道路徑。注意：所有現有檔案將被覆蓋。"
 
 msgid "The game is on SD Card."
 msgstr "遊戲在SD卡上。"
@@ -2143,13 +2140,13 @@ msgid "The game is on USB."
 msgstr "遊戲在USB上。"
 
 msgid "The save game will be extracted to your EmuNAND path."
-msgstr "保存的遊戲將被提取到您的EmuNAND路徑。"
+msgstr "儲存的遊戲將被擷取到您的EmuNAND路徑。"
 
 msgid "The save games will be extracted to your EmuNAND save and channel path. Attention: All existing files will be overwritten."
-msgstr "保存的遊戲將被提取到您的EmuNAND保存和頻道路徑。注意：所有現有文件將被覆蓋。"
+msgstr "儲存的遊戲將被擷取到您的EmuNAND存檔和頻道路徑。注意：所有現有檔案將被覆蓋。"
 
 msgid "Theme Menu"
-msgstr "主題菜單"
+msgstr "主題選單"
 
 msgid "Theme Path"
 msgstr "主題路徑"
@@ -2167,19 +2164,19 @@ msgid "This IOS was not found on the titles list. If you are sure you have it in
 msgstr "在標題列表中未找到此IOS。如果您確定已安裝它，則忽略此警告。"
 
 msgid "This Nintendont version does not support games on USB."
-msgstr "此Nintendont版本不支持USB上的遊戲。"
+msgstr "此Nintendont版本不支援USB上的遊戲。"
 
 msgid "This Nintendont version is not correctly supported. Auto boot disabled."
-msgstr "此Nintendont版本不正確支持。自動啟動已禁用。"
+msgstr "此Nintendont版本不正確支援。自動啟動已禁用。"
 
 msgid "This game has multiple discs. Please select the disc to launch."
-msgstr "此遊戲有多張光盤。請選擇要啟動的光盤。"
+msgstr "此遊戲有多張光碟。請選擇要啟動的光碟。"
 
 msgid "This path must be on SD!"
-msgstr "此路徑必須在SD上！"
+msgstr "此路徑必須在SD卡上！"
 
 msgid "This setting doesn't work in SD card mode."
-msgstr "此設置在SD卡模式下不起作用。"
+msgstr "此設定在SD卡模式下不起作用。"
 
 msgid "Time left:"
 msgstr "剩餘時間："
@@ -2197,54 +2194,54 @@ msgid "Titles Path"
 msgstr "標題路徑"
 
 msgid "To run GameCube games from disc you need to set the GameCube mode to MIOS in the game settings."
-msgstr "要從光盤運行GameCube遊戲，您需要在遊戲設置中將GameCube模式設置為MIOS。"
+msgstr "要從光碟運行GameCube遊戲，您需要在遊戲設定中將GameCube模式設定為MIOS。"
 
 #, c-format
 msgid "To run GameCube games with %s you need to place them on an USB FAT32 partition."
-msgstr "要使用%s運行GameCube遊戲，您需要將它們放在USB FAT32分區上。"
+msgstr "要使用%s運行GameCube遊戲，您需要將它們放在USB FAT32分割區上。"
 
 #, c-format
 msgid "To run GameCube games with %s you need to set your 'Main GameCube Path' on the first primary FAT32 partition."
-msgstr "要使用%s運行GameCube遊戲，您需要在第一個主要FAT32分區上設置您的'主GameCube路徑'。"
+msgstr "要使用%s運行GameCube遊戲，您需要在第一個主要FAT32分割區上設定您的'主GameCube路徑'。"
 
 #, c-format
 msgid "To run GameCube games with %s you need to set your 'Main GameCube Path' on the first primary partition of the Hard Drive."
-msgstr "要使用%s運行GameCube遊戲，您需要在硬盤的第一個主要分區上設置您的'主GameCube路徑'。"
+msgstr "要使用%s運行GameCube遊戲，您需要在硬碟的第一個主要分割區上設定您的'主GameCube路徑'。"
 
 #, c-format
 msgid "To run GameCube games with %s you need to set your 'Main GameCube Path' to an USB FAT32 partition."
-msgstr "要使用%s運行GameCube遊戲，您需要將您的'主GameCube路徑'設置為USB FAT32分區。"
+msgstr "要使用%s運行GameCube遊戲，您需要將您的'主GameCube路徑'設定為USB FAT32分割區。"
 
 #, c-format
 msgid "To run GameCube games with %s you need to use a 512 bytes/sector Hard Drive."
-msgstr "要使用%s運行GameCube遊戲，您需要使用512字節/扇區的硬盤。"
+msgstr "要使用%s運行GameCube遊戲，您需要使用512位元組/磁區的硬碟。"
 
 #, c-format
 msgid "To run GameCube games with %s you need to use a partition with 32k bytes/cluster or less."
-msgstr "要使用%s運行GameCube遊戲，您需要使用每簇32k字節或更少的分區。"
+msgstr "要使用%s運行GameCube遊戲，您需要使用32k位元組/叢集或更少的分割區。"
 
 msgid "To run GameCube games with Devolution you need the loader.bin file in your Devolution Loader Path."
-msgstr "要使用Devolution運行GameCube遊戲，您需要在Devolution加載器路徑中有loader.bin文件。"
+msgstr "要使用Devolution運行GameCube遊戲，您需要在Devolution載入器路徑中有loader.bin檔案。"
 
 msgid "To run GameCube games with Nintendont you need the boot.dol file in your Nintendont Loader Path."
-msgstr "要使用Nintendont運行GameCube遊戲，您需要在Nintendont加載器路徑中有boot.dol文件。"
+msgstr "要使用Nintendont運行GameCube遊戲，您需要在Nintendont載入器路徑中有boot.dol檔案。"
 
 #, c-format
 msgid "To use HID with %s you need the %s file."
-msgstr "要使用HID與%s，您需要%s文件。"
+msgstr "要使用HID與%s，您需要%s檔案。"
 
 #, c-format
 msgid "To use Ocarina with %s you need the %s file."
-msgstr "要使用Ocarina與%s，您需要%s文件。"
+msgstr "要使用Ocarina與%s，您需要%s檔案。"
 
 msgid "To use neek you need to set your 'EmuNAND Channel Path' on the first primary partition of the Hard Drive."
-msgstr "要使用neek，您需要在硬盤的第一個主要分區上設置您的'EmuNAND頻道路徑'。"
+msgstr "要使用neek，您需要在硬碟的第一個主要分割區上設定您的'EmuNAND頻道路徑'。"
 
 msgid "To use neek you need to set your 'EmuNAND Channel Path' to a FAT32 partition."
-msgstr "要使用neek，您需要將您的'EmuNAND頻道路徑'設置為FAT32分區。"
+msgstr "要使用neek，您需要將您的'EmuNAND頻道路徑'設定為FAT32分割區。"
 
 msgid "To use neek you need to use a 512 bytes/sector Hard Drive."
-msgstr "要使用neek，您需要使用512字節/扇區的硬盤。"
+msgstr "要使用neek，您需要使用512位元組/磁區的硬碟。"
 
 msgid "Toggle SD card mode"
 msgstr "切換SD卡模式"
@@ -2265,43 +2262,43 @@ msgid "USB"
 msgstr "USB"
 
 msgid "USB Device not initialized."
-msgstr "USB設備未初始化。"
+msgstr "USB裝置未初始化。"
 
 msgid "USB Loader GX couldn't verify Nintendont boot.dol file. Launch this boot.dol anyway?"
-msgstr "USB Loader GX無法驗證Nintendont boot.dol文件。仍然啟動此boot.dol？"
+msgstr "USB Loader GX無法驗證Nintendont boot.dol檔案。仍然啟動此boot.dol？"
 
 msgid "USB Loader GX couldn't write Nintendont config file. Launch Nintendont anyway?"
-msgstr "USB Loader GX無法寫入Nintendont配置文件。仍然啟動Nintendont？"
+msgstr "USB Loader GX無法寫入Nintendont設置檔案。仍然啟動Nintendont？"
 
 msgid "USB Loader GX is protected"
 msgstr "USB Loader GX已受保護"
 
 msgid "USB Loader GX needs to be installed to an SD card for this setting to work."
-msgstr "USB Loader GX需要安裝到SD卡上才能使此設置生效。"
+msgstr "USB Loader GX需要安裝到SD卡上才能使此設定生效。"
 
 msgid "USB Loader GX r1218 is required for Nintendont Alpha v0.1. Please update your Nintendont boot.dol version."
 msgstr "Nintendont Alpha v0.1需要USB Loader GX r1218。請更新您的Nintendont boot.dol版本。"
 
 msgid "USB Port"
-msgstr "USB端口"
+msgstr "USB埠"
 
 msgid "USB Port changing is only supported on Hermes cIOS."
-msgstr "USB端口更改僅支持Hermes cIOS。"
+msgstr "USB埠更改僅支援Hermes cIOS。"
 
 msgid "USB-HID Controller"
 msgstr "USB-HID控制器"
 
 msgid "Uninstall"
-msgstr "卸載"
+msgstr "解除安裝"
 
 msgid "Uninstall Game"
-msgstr "卸載遊戲"
+msgstr "解除安裝遊戲"
 
 msgid "Uninstall Menu"
-msgstr "卸載菜單"
+msgstr "解除安裝選單"
 
 msgid "Uninstall all"
-msgstr "卸載所有"
+msgstr "解除安裝所有"
 
 msgid "Unknown"
 msgstr "未知"
@@ -2313,28 +2310,28 @@ msgid "Unlocked"
 msgstr "已解鎖"
 
 msgid "Unsupported format!"
-msgstr "不支持的格式！"
+msgstr "不支援的格式！"
 
 msgid "Update"
 msgstr "更新"
 
 msgid "Update All Language Files"
-msgstr "更新所有語言文件"
+msgstr "更新所有語言檔案"
 
 msgid "Update Cheat Files"
-msgstr "更新作弊文件"
+msgstr "更新作弊檔案"
 
 msgid "Update Cover Files"
-msgstr "更新封面文件"
+msgstr "更新封面檔案"
 
 msgid "Update Failed"
 msgstr "更新失敗"
 
 msgid "Update Language Files"
-msgstr "更新語言文件"
+msgstr "更新語言檔案"
 
 msgid "Update Menu"
-msgstr "更新菜單"
+msgstr "更新選單"
 
 msgid "Update Nintendont"
 msgstr "更新Nintendont"
@@ -2346,19 +2343,19 @@ msgid "Update WiiTDB.xml"
 msgstr "更新WiiTDB.xml"
 
 msgid "Updating Language Files:"
-msgstr "正在更新語言文件："
+msgstr "正在更新語言檔案："
 
 msgid "Uploaded ZIP file installed to homebrew directory."
-msgstr "上傳的ZIP文件已安裝到homebrew目錄。"
+msgstr "上傳的ZIP檔案已安裝到homebrew目錄。"
 
 msgid "Use System Font"
 msgstr "使用系統字體"
 
 msgid "Use global"
-msgstr "使用全局"
+msgstr "使用全域"
 
 msgid "VBI (Default)"
-msgstr "VBI（默認）"
+msgstr "VBI（預設）"
 
 msgid "VIDTV Patch"
 msgstr "VIDTV補丁"
@@ -2371,28 +2368,28 @@ msgid "Version: %s"
 msgstr "版本：%s"
 
 msgid "Video Deflicker"
-msgstr "視頻去閃"
+msgstr "影像去閃爍"
 
 msgid "Video Mode"
-msgstr "視頻模式"
+msgstr "影像模式"
 
 msgid "Video Scale Value"
-msgstr "視頻縮放值"
+msgstr "影像縮放值"
 
 msgid "Video Width"
-msgstr "視頻寬度"
+msgstr "影像寬度"
 
 msgid "Video offset"
-msgstr "視頻偏移"
+msgstr "影像偏移"
 
 msgid "Video scale"
-msgstr "視頻縮放"
+msgstr "影像縮放"
 
 msgid "Virtual Pointer Speed"
 msgstr "虛擬指針速度"
 
 msgid "WDM Files Path"
-msgstr "WDM 文件路徑"
+msgstr "WDM 檔案路徑"
 
 msgid "WIP Patches Path"
 msgstr "WIP 補丁路徑"
@@ -2413,16 +2410,16 @@ msgid "What should be deleted for this game title:"
 msgstr "應該刪除這個遊戲標題的什麼："
 
 msgid "What to extract from NAND?"
-msgstr "從 NAND 提取什麼？"
+msgstr "從 NAND 擷取什麼？"
 
 msgid "Where Should the Game Be Installed To?"
 msgstr "遊戲應安裝到哪裡？"
 
 msgid "Where to dump NAND?"
-msgstr "將 NAND 轉儲到哪裡？"
+msgstr "將 NAND 傾印到哪裡？"
 
 msgid "Which device do you want to use for Nintendont files?"
-msgstr "您想使用哪個設備來存放 Nintendont 文件？"
+msgstr "您想使用哪個裝置來存放 Nintendont 檔案？"
 
 msgid "Which mode do you want to use?"
 msgstr "您想使用哪種模式？"
@@ -2431,25 +2428,25 @@ msgid "WiFi Features"
 msgstr "WiFi 功能"
 
 msgid "Widescreen Factor"
-msgstr "寬屏因子"
+msgstr "寬螢幕因子"
 
 msgid "Widescreen Fix"
-msgstr "寬屏修復"
+msgstr "寬螢幕修復"
 
 msgid "Wii"
 msgstr "Wii"
 
 msgid "Wii Menu"
-msgstr "Wii 菜單"
+msgstr "Wii 選單"
 
 msgid "Wii Settings"
-msgstr "Wii 設置"
+msgstr "Wii 設定"
 
 msgid "Wii U GamePad Slot"
-msgstr "Wii U 遊戲手柄插槽"
+msgstr "Wii U 遊戲手把插槽"
 
 msgid "Wii U Widescreen"
-msgstr "Wii U 寬屏"
+msgstr "Wii U 寬螢幕"
 
 msgid "WiiTDB.xml is up to date."
 msgstr "WiiTDB.xml 是最新的。"
@@ -2467,14 +2464,14 @@ msgid "Wiinnertag Path"
 msgstr "Wiinnertag 路徑"
 
 msgid "Wiinnertag requires you to enable automatic network connect on application start. Do you want to enable it now?"
-msgstr "Wiinnertag 需要您在應用程序啟動時啟用自動網絡連接。您現在要啟用它嗎？"
+msgstr "Wiinnertag 需要您在應用程式啟動時啟用自動網路連接。您現在要啟用它嗎？"
 
 msgid "Wiird Debugger"
-msgstr "Wiird 調試器"
+msgstr "Wiird 除錯器"
 
 #, c-format
 msgid "Write error on file: %s"
-msgstr "文件寫入錯誤：%s"
+msgstr "檔案寫入錯誤：%s"
 
 msgid "Writing GXGameCategories.xml"
 msgstr "正在寫入 GXGameCategories.xml"
@@ -2486,49 +2483,49 @@ msgid "Yes"
 msgstr "是"
 
 msgid "You are trying to select a FAT32/NTFS/EXT partition with cIOS 249 Rev < 18. This is not supported. Continue on your own risk."
-msgstr "您正在嘗試選擇 cIOS 249 Rev < 18 的 FAT32/NTFS/EXT 分區。這不受支持。繼續操作風險自負。"
+msgstr "您正在嘗試選擇 cIOS 249 Rev < 18 的 FAT32/NTFS/EXT 分割區。這不受支援。繼續操作風險自負。"
 
 msgid "You can select or format a partition or use the channel loader mode."
-msgstr "您可以選擇或格式化分區，或使用頻道加載模式。"
+msgstr "您可以選擇或格式化分割區，或使用頻道載入模式。"
 
 msgid "You cannot delete this category."
 msgstr "您不能刪除此類別。"
 
 msgid "You have DIOS-MIOS installed, so this game needs to be on a FAT32 USB storage device. You'll need to install DIOS-MIOS Lite to run this game from an SD card."
-msgstr "您已安裝 DIOS-MIOS，因此此遊戲需要在 FAT32 USB 存儲設備上。您需要安裝 DIOS-MIOS Lite 才能從 SD 卡運行此遊戲。"
+msgstr "您已安裝 DIOS-MIOS，因此此遊戲需要在 FAT32 USB 儲存裝置上。您需要安裝 DIOS-MIOS Lite 才能從 SD 卡運行此遊戲。"
 
 msgid "You need neek2o to load EmuNAND from sub-folders."
-msgstr "您需要 neek2o 來從子文件夾加載 EmuNAND。"
+msgstr "您需要 neek2o 來從子資料夾載入 EmuNAND。"
 
 msgid "You need to install DIOS MIOS Lite v1.2 or a newer version."
 msgstr "您需要安裝 DIOS MIOS Lite v1.2 或更新版本。"
 
 msgid "You need to install an additional GameCube loader or select a different GameCube Mode to launch GameCube games from USB or SD card."
-msgstr "您需要安裝額外的 GameCube 加載器或選擇不同的 GameCube 模式來從 USB 或 SD 卡啟動 GameCube 遊戲。"
+msgstr "您需要安裝額外的 GameCube 載入器或選擇不同的 GameCube 模式來從 USB 或 SD 卡啟動 GameCube 遊戲。"
 
 msgid "Your current GameCube partition is not compatible. Please update Nintendont."
-msgstr "您當前的 GameCube 分區不兼容。請更新 Nintendont。"
+msgstr "您當前的 GameCube 分割區不兼容。請更新 Nintendont。"
 
 msgid "Zoom Duration (Speed)"
 msgstr "縮放持續時間（速度）"
 
 msgid "and translators for language files updates"
-msgstr "以及語言文件更新的翻譯者"
+msgstr "以及語言檔案更新的翻譯者"
 
 msgid "does not exist!"
 msgstr "不存在！"
 
 msgid "does not exist!  Loading game without cheats."
-msgstr "不存在！ 加載遊戲不使用作弊。"
+msgstr "不存在！ 載入遊戲不使用作弊。"
 
 msgid "files left"
-msgstr "剩餘文件"
+msgstr "剩餘檔案"
 
 msgid "for FAT/NTFS support"
-msgstr "支持 FAT/NTFS"
+msgstr "支援 FAT/NTFS"
 
 msgid "for GameTDB and hosting covers / disc images"
-msgstr "用於 GameTDB 和托管封面/光盤圖像"
+msgstr "用於 GameTDB 和托管封面/光碟圖像"
 
 msgid "for Ocarina"
 msgstr "用於 Ocarina"
@@ -2540,7 +2537,7 @@ msgid "for his awesome tool LibWiiGui"
 msgstr "用於他出色的工具 LibWiiGui"
 
 msgid "for the USB Loader source"
-msgstr "用於 USB 加載器源"
+msgstr "用於 USB 載入器源"
 
 msgid "for their work on the wiki page"
 msgstr "感謝他們在 wiki 頁面上的工作"
@@ -2549,13 +2546,13 @@ msgid "formatted!"
 msgstr "已格式化！"
 
 msgid "free"
-msgstr "免費"
+msgstr "可用"
 
 msgid "ms"
 msgstr "毫秒"
 
 msgid "of"
-msgstr "的"
+msgstr "自"
 
 msgid "seconds left"
 msgstr "剩餘秒數"


### PR DESCRIPTION
The previous version for the Traditional Chinese translation was basically only changing the characters from the Simplified Chinese translation, which was far from ideal as these two languages have their own conventional wordings in technical term translations.

I did mostly direct replacements for translations of technical terms to the corresponding conventional wordings. The choices are based on years of user experience and this open-source [comparison table](https://zh.wikibooks.org/w/index.php?title=%E5%A4%A7%E9%99%86%E5%8F%B0%E6%B9%BE%E8%AE%A1%E7%AE%97%E6%9C%BA%E6%9C%AF%E8%AF%AD%E5%AF%B9%E7%85%A7%E8%A1%A8).

Most of the word lengths remain the same, with a few exceptions: one to two Chinese characters increase at most.