### PR TITLE
[QOL] Add a game renaming feature

### DIFF
--- a/source/settings/CGameSettings.cpp
+++ b/source/settings/CGameSettings.cpp
@@ -252,7 +252,8 @@ bool CGameSettings::Save()
 		fprintf(f, "DEVODiscDelay:%d; ", GameList[i].DEVODiscDelay);
 		fprintf(f, "PrivateServer:%d; ", GameList[i].PrivateServer);
 		fprintf(f, "CustomAddress:%s; ", GameList[i].CustomAddress.c_str());
-		fprintf(f, "Locked:%d;\n", GameList[i].Locked);
+		fprintf(f, "Locked:%d; ", GameList[i].Locked);
+		fprintf(f, "gametitle:%s;\n", GameList[i].GameTitle.c_str());
 	}
 	fprintf(f, "# END\n");
 	fclose(f);
@@ -608,6 +609,11 @@ bool CGameSettings::SetSetting(GameCFG & game, const char *name, const char *val
 			game.CustomAddress = value;
 		return true;
 	}
+	else if(strcmp(name, "gametitle") == 0)
+	{
+		game.GameTitle = value;
+		return true;
+	}
 
 	return false;
 }
@@ -778,4 +784,5 @@ void CGameSettings::SetDefault(GameCFG &game)
 	game.PrivateServer = INHERIT;
 	game.CustomAddress.clear();
 	game.Locked = OFF;
+	game.GameTitle.clear();
 }

--- a/source/settings/CGameSettings.cpp
+++ b/source/settings/CGameSettings.cpp
@@ -49,6 +49,7 @@ GameCFG * CGameSettings::GetGameCFG(const char * id)
 	if(!id)
 	{
 		DefaultConfig.id[0] = '\0';
+		DefaultConfig.GameTitle.clear();
 		return &DefaultConfig;
 	}
 
@@ -59,6 +60,8 @@ GameCFG * CGameSettings::GetGameCFG(const char * id)
 	}
 
 	memcpy(DefaultConfig.id, id, 6);
+	// Ensure the default config doesn't carry over a title from a previous lookup
+	DefaultConfig.GameTitle.clear();
 
 	return &DefaultConfig;
 }

--- a/source/settings/CGameSettings.h
+++ b/source/settings/CGameSettings.h
@@ -79,6 +79,7 @@ typedef struct _GameCFG
 	short PrivateServer;
 	std::string CustomAddress;
 	short Locked;
+	std::string GameTitle;
 
 	void operator=(const struct _GameCFG &game)
 	{
@@ -152,6 +153,7 @@ typedef struct _GameCFG
 		this->PrivateServer = game.PrivateServer;
 		this->CustomAddress = game.CustomAddress;
 		this->Locked = game.Locked;
+		this->GameTitle = game.GameTitle;
 	}
 } GameCFG;
 

--- a/source/settings/CGameSettings.h
+++ b/source/settings/CGameSettings.h
@@ -81,6 +81,13 @@ typedef struct _GameCFG
 	short Locked;
 	std::string GameTitle;
 
+	_GameCFG() {}
+
+	_GameCFG(const struct _GameCFG &game)
+	{
+		*this = game;
+	}
+
 	void operator=(const struct _GameCFG &game)
 	{
 		memcpy(this->id, game.id, sizeof(game.id));

--- a/source/settings/GameTitles.cpp
+++ b/source/settings/GameTitles.cpp
@@ -4,6 +4,7 @@
 
 #include "GameTitles.h"
 #include "CSettings.h"
+#include "CGameSettings.h"
 #include "usbloader/GameList.h"
 #include "Channels/channels.h"
 #include "xml/GameTDB.hpp"
@@ -58,6 +59,11 @@ const char *CGameTitles::GetTitle(const char *id, bool allow_access) const
 	if (!id)
 		return "";
 
+	// Check manual override from CGameSettings first
+	GameCFG *cfg = GameSettings.GetGameCFG(id);
+	if(cfg && !cfg->GameTitle.empty())
+		return cfg->GameTitle.c_str();
+
 	auto game = std::lower_bound(TitleList.begin(), TitleList.end(), id, [](const GameTitle &gt, const char *gameid)
 								 { return (strncasecmp(gt.GameID, gameid, 6) < 0); });
 	if (game != TitleList.end())
@@ -82,6 +88,11 @@ const char *CGameTitles::GetTitle(const struct discHdr *header) const
 {
 	if (!header)
 		return "";
+
+	// Check manual override from CGameSettings first
+	GameCFG *cfg = GameSettings.GetGameCFG(header->id);
+	if(cfg && !cfg->GameTitle.empty())
+		return cfg->GameTitle.c_str();
 
 	auto game = std::lower_bound(TitleList.begin(), TitleList.end(), (const char *)header->id, [](const GameTitle &gt, const char *gameid)
 								 { return (strncasecmp(gt.GameID, gameid, 6) < 0); });

--- a/source/settings/menus/GameSettingsMenu.cpp
+++ b/source/settings/menus/GameSettingsMenu.cpp
@@ -126,7 +126,12 @@ void GameSettingsMenu::CreateSettingsMenu(int menuNr)
 			GameCFG * game = GameSettings.GetGameCFG(DiscHeader->id);
 			if(game)
 			{
-				game->GameTitle = entered;
+				// Create a copy to ensure we don't modify the DefaultConfig pointer directly
+				// and to ensure we add the new config to the persistent list.
+				GameCFG GameConfig = *game;
+				GameConfig.GameTitle = entered;
+				
+				GameSettings.AddGame(GameConfig);
 				GameSettings.Save();
 				
 				// Update the title in memory immediately so it reflects in the GUI

--- a/source/settings/menus/GameSettingsMenu.cpp
+++ b/source/settings/menus/GameSettingsMenu.cpp
@@ -141,6 +141,9 @@ void GameSettingsMenu::CreateSettingsMenu(int menuNr)
 				MenuTitle = entered;
 				if(titleTxt)
 					titleTxt->SetText(entered);
+
+				// Sort the list so the new name moves to the correct alphabetical position
+				gameList.SortList();
 				
 				// Refresh browser list on exit
 				browserMenu->ReloadBrowser();

--- a/source/settings/menus/GameSettingsMenu.cpp
+++ b/source/settings/menus/GameSettingsMenu.cpp
@@ -70,6 +70,7 @@ void GameSettingsMenu::SetupMainButtons()
 	int pos = 0;
 
 	SetMainButton(pos++, tr( "Game Load" ), MainButtonImgData, MainButtonImgOverData);
+	SetMainButton(pos++, tr( "Rename Game" ), MainButtonImgData, MainButtonImgOverData);
 	SetMainButton(pos++, tr( "Ocarina" ), MainButtonImgData, MainButtonImgOverData);
 	SetMainButton(pos++, tr( "Categories" ), MainButtonImgData, MainButtonImgOverData);
 	if(		DiscHeader->type == TYPE_GAME_WII_IMG
@@ -105,6 +106,41 @@ void GameSettingsMenu::CreateSettingsMenu(int menuNr)
 			CurrentMenu = new GameLoadSM(DiscHeader);
 		}
 		Append(CurrentMenu);
+	}
+
+	//! Rename Game
+	else if(menuNr == Idx++)
+	{
+		if (!Settings.godmode && (Settings.ParentalBlocks & BLOCK_GAME_SETTINGS))
+		{
+			WindowPrompt(tr( "Permission denied." ), tr( "Console must be unlocked for this option." ), tr( "OK" ));
+			return;
+		}
+
+		char entered[100];
+		snprintf(entered, sizeof(entered), "%s", GameTitles.GetTitle(DiscHeader));
+		
+		int ret = OnScreenKeyboard(entered, sizeof(entered), 0);
+		if(ret)
+		{
+			GameCFG * game = GameSettings.GetGameCFG(DiscHeader->id);
+			if(game)
+			{
+				game->GameTitle = entered;
+				GameSettings.Save();
+				
+				// Update the title in memory immediately so it reflects in the GUI
+				GameTitles.SetGameTitle((const char *)DiscHeader->id, entered, TITLETYPE_MANUAL_OVERRIDE, "NULL", -1, 1);
+				
+				// Update the menu header
+				MenuTitle = entered;
+				if(titleTxt)
+					titleTxt->SetText(entered);
+				
+				// Refresh browser list on exit
+				browserMenu->ReloadBrowser();
+			}
+		}
 	}
 
 	//! Ocarina


### PR DESCRIPTION
Adds a button to the game settings menu that allows the user to visually rename a game on the list.
This renaming feature is purely visual and does not modify any game files. Renamed games keep their new names across reboots.
I created this because I found memorizing the game's internal name annoying.
I would love to see this feature in release. If anything needs to be changed or reworked then please let me know.