### PR TITLE
Fix loading games that require an IOS reload on USB1

### DIFF
--- a/source/system/IosLoader.cpp
+++ b/source/system/IosLoader.cpp
@@ -174,6 +174,7 @@ s32 IosLoader::LoadGameCios(s32 ios)
 	WBFS_CloseAll();
 	WDVD_Close();
 	DeviceHandler::Instance()->UnMountSD();
+	DeviceHandler::Instance()->UnMountAllUSB();
 	DeviceHandler::DestroyInstance();
 	USBStorage2_Deinit();
 

--- a/source/usbloader/usbstorage2.c
+++ b/source/usbloader/usbstorage2.c
@@ -119,6 +119,10 @@ void USBStorage2_Deinit()
 		MEM2_free(mem2_ptr);
 		mem2_ptr = NULL;
 	}
+	if (usb2_port > 0)
+	{
+		usb2_port = 0;
+	}
 }
 
 s32 USBStorage2_SetPort(u32 port)


### PR DESCRIPTION
On the latest release, trying to load any game that requires an IOS reload on a device connected over USB1 fails, due to USBStorage2 not being properly clean up prior to the reload, with the USB device failing to be re-initialized after the reload.

This PR fixes that by properly unmounting all USB devices and setting the USB port back to zero on `USBStorage2_Deinit`, allowing USB re-init to work after a reload. 