### PR TITLE
Add option to disable HDD power saving

### DIFF
--- a/source/StartUpProcess.cpp
+++ b/source/StartUpProcess.cpp
@@ -19,6 +19,7 @@
 #include "settings/CGameCategories.hpp"
 #include "settings/GameTitles.h"
 #include "usbloader/usbstorage2.h"
+#include "usbloader/usbstorage_libogc.h"
 #include "usbloader/MountGamePartition.h"
 #include "usbloader/GameBooter.hpp"
 #include "usbloader/GameList.h"
@@ -365,6 +366,44 @@ int StartUpProcess::Execute(bool quickGameBoot, bool isBadBoot)
 	gprintf("\tLoading game statistics...%s\n", GameStatistics.Load(Settings.ConfigPath) ? "done" : "failed");
 	gprintf("\tLoading game categories...%s\n", GameCategories.Load(Settings.ConfigPath) ? "done" : "failed");
 	gprintf("\tLoading cached titles...%s\n", GameTitles.ReadCachedTitles(Settings.titlestxt_path) ? "done" : "failed (using default)");
+
+	// Apply volatile ATA power settings while the IOS58/libogc USB backend is
+	// still mounted. The later cIOS backend does not expose raw SCSI commands.
+	if (Settings.DisableHDDPowerSaving && USBSuccess)
+	{
+		if (IOS_GetVersion() == 58)
+		{
+			SetTextf("Disabling HDD power saving\n");
+			s32 result = USBStorage_OGC_DisablePowerSaving();
+			if (result == USBSTORAGE_POWER_ALL_DISABLED)
+			{
+				SetTextf("HDD power saving disabled\n");
+				gprintf("Disable HDD power saving: APM and standby timer disabled\n");
+			}
+			else if (result > 0)
+			{
+				SetTextf("HDD power saving partially disabled\n");
+				gprintf("Disable HDD power saving: APM %s, standby timer %s\n",
+					(result & USBSTORAGE_POWER_APM_DISABLED) ? "disabled" : "failed",
+					(result & USBSTORAGE_POWER_STANDBY_DISABLED) ? "disabled" : "failed");
+			}
+			else if (result == 0)
+			{
+				SetTextf("HDD power saving not supported\n");
+				gprintf("Disable HDD power saving: ATA power commands not supported\n");
+			}
+			else
+			{
+				SetTextf("HDD power saving command failed\n");
+				gprintf("Disable HDD power saving: transport error (%i)\n", result);
+			}
+		}
+		else
+		{
+			SetTextf("HDD power saving requires IOS58\n");
+			gprintf("Disable HDD power saving: skipped (requires IOS58 USB backend)\n");
+		}
+	}
 
 	// Some settings need to be enabled to boot directly into games
 	gprintf("Quick game boot: %s\n", quickGameBoot ? "yes" : "no");

--- a/source/settings/CSettings.cpp
+++ b/source/settings/CSettings.cpp
@@ -156,6 +156,7 @@ void CSettings::SetDefault()
 	MultiplePartitions = OFF;
 	BlockIOSReload = AUTO;
 	USBPort = 0;
+	DisableHDDPowerSaving = OFF;
 	WSFactor = 0.8f; //actually should be 0.75 for real widescreen
 	FontScaleFactor = 0.8f; //it's a work around to not have to change ALL fonts now
 	ClockFontScaleFactor = 1.0f; // Scale of 1 to prevent misaligned clock.
@@ -414,6 +415,7 @@ bool CSettings::Save()
 	fprintf(file, "SilentHomeMenu = %d\n", SilentHomeMenu);
 	fprintf(file, "MultiplePartitions = %d\n", MultiplePartitions);
 	fprintf(file, "USBPort = %d\n", USBPort);
+	fprintf(file, "DisableHDDPowerSaving = %d\n", DisableHDDPowerSaving);
 	fprintf(file, "BlockIOSReload = %d\n", BlockIOSReload);
 	fprintf(file, "WSFactor = %0.3f\n", WSFactor);
 	fprintf(file, "FontScaleFactor = %0.3f\n", FontScaleFactor);
@@ -827,6 +829,11 @@ bool CSettings::SetSetting(char *name, char *value)
 	else if (strcmp(name, "USBPort") == 0)
 	{
 		USBPort = atoi(value);
+		return true;
+	}
+	else if (strcmp(name, "DisableHDDPowerSaving") == 0)
+	{
+		DisableHDDPowerSaving = atoi(value);
 		return true;
 	}
 	else if (strcmp(name, "patchcountrystrings") == 0)

--- a/source/settings/CSettings.h
+++ b/source/settings/CSettings.h
@@ -159,6 +159,7 @@ class CSettings
 		short SilentHomeMenu;
 		short MultiplePartitions;
 		short USBPort;
+		short DisableHDDPowerSaving;
 		short BlockIOSReload;
 		u32 InstallPartitions;
 		u32 ParentalBlocks;

--- a/source/settings/menus/HardDriveSM.cpp
+++ b/source/settings/menus/HardDriveSM.cpp
@@ -88,6 +88,7 @@ HardDriveSM::HardDriveSM()
 	if (strncmp(Settings.ConfigPath, "sd", 2) == 0)
 		Options->SetName(Idx++, "%s", tr( "SD Card Mode" ));
 	Options->SetName(Idx++, "%s", tr( "USB Port" ));
+	Options->SetName(Idx++, "%s", tr( "Disable HDD Power Saving" ));
 	Options->SetName(Idx++, "%s", tr( "Install Directories" ));
 	Options->SetName(Idx++, "%s", tr( "Game Split Size" ));
 	Options->SetName(Idx++, "%s", tr( "Install Partitions" ));
@@ -185,6 +186,9 @@ void HardDriveSM::SetOptionValues()
 	else
 		Options->SetValue(Idx++, "%i", NewSettingsUSBPort);
 
+	//! Settings: Disable HDD power saving
+	Options->SetValue(Idx++, "%s", tr( OnOffText[Settings.DisableHDDPowerSaving] ));
+
 	//! Settings: Install directories
 	Options->SetValue(Idx++, "%s", tr( InstallToText[Settings.InstallToDir] ));
 
@@ -272,6 +276,20 @@ int HardDriveSM::GetMenuInternal()
 
 		else if (++NewSettingsUSBPort >= 3) // 2 = both ports
 			NewSettingsUSBPort = 0;
+	}
+
+	//! Settings: Disable HDD power saving
+	else if (ret == ++Idx)
+	{
+		if (++Settings.DisableHDDPowerSaving >= MAX_ON_OFF)
+			Settings.DisableHDDPowerSaving = 0;
+
+		if (Settings.DisableHDDPowerSaving == ON)
+		{
+			WindowPrompt(0,
+				tr("Applied on the next launch after testing ATA support. This may keep a mechanical HDD spinning, increasing power use, heat, noise, and running time."),
+				tr("OK"));
+		}
 	}
 
 	//! Settings: Install directories

--- a/source/usbloader/usbstorage_libogc.c
+++ b/source/usbloader/usbstorage_libogc.c
@@ -234,7 +234,7 @@ static s32 __send_cbw(usbstorage_handle *dev, u8 lun, u32 len, u8 flags, const u
 	__stwbrx(cbw_buffer, 8, len);
 	cbw_buffer[12] = flags;
 	cbw_buffer[13] = lun;
-	cbw_buffer[14] = (cbLen > 6 ? 10 : 6);
+	cbw_buffer[14] = (cbLen > 6 ? cbLen : 6);
 
 	memcpy(cbw_buffer + 15, cb, cbLen);
 
@@ -1011,6 +1011,56 @@ int USBStorage_OGC_ioctl(int request, ...)
     
     va_end(ap);
     return retval;
+}
+
+static s32 __usbstorage_ogc_ata_nodata(u8 ata_command, u8 feature)
+{
+    raw_device_command rdc;
+    s32 retval;
+
+    memset(&rdc, 0, sizeof(rdc));
+    rdc.command[0] = 0x85; /* ATA PASS-THROUGH (16) */
+    rdc.command[1] = 0x06; /* Non-data protocol */
+    rdc.command[2] = 0x0c;
+    rdc.command[4] = feature;
+    rdc.command[14] = ata_command;
+    rdc.command_length = sizeof(rdc.command);
+    rdc.flags = B_RAW_DEVICE_DATA_IN;
+
+    retval = USBStorage_OGC_ioctl(B_RAW_DEVICE_COMMAND, &rdc);
+    if (retval < 0)
+        return retval;
+
+    return rdc.scsi_status == 0 ? USBSTORAGE_OK : USBSTORAGE_ESTATUS;
+}
+
+s32 USBStorage_OGC_DisablePowerSaving()
+{
+    /* CHECK POWER MODE does not change drive state. */
+    s32 retval = __usbstorage_ogc_ata_nodata(0xe5, 0x00);
+    if (retval == USBSTORAGE_ESTATUS)
+        return 0;
+    if (retval < 0)
+        return retval;
+
+    s32 result = 0;
+    s32 transport_error = 0;
+
+    /* SET FEATURES, DISABLE APM. */
+    retval = __usbstorage_ogc_ata_nodata(0xef, 0x85);
+    if (retval == USBSTORAGE_OK)
+        result |= USBSTORAGE_POWER_APM_DISABLED;
+    else if (retval != USBSTORAGE_ESTATUS)
+        transport_error = retval;
+
+    /* IDLE with sector count zero disables the standby timer. */
+    retval = __usbstorage_ogc_ata_nodata(0xe3, 0x00);
+    if (retval == USBSTORAGE_OK)
+        result |= USBSTORAGE_POWER_STANDBY_DISABLED;
+    else if (retval != USBSTORAGE_ESTATUS && transport_error == 0)
+        transport_error = retval;
+
+    return result != 0 ? result : transport_error;
 }
 
 DISC_INTERFACE __io_usbstorage_ogc = {

--- a/source/usbloader/usbstorage_libogc.h
+++ b/source/usbloader/usbstorage_libogc.h
@@ -28,6 +28,19 @@ s32 USBStorage_OGC_Read(usbstorage_handle *dev, u8 lun, u32 sector, u16 n_sector
 s32 USBStorage_OGC_Write(usbstorage_handle *dev, u8 lun, u32 sector, u16 n_sectors, const u8 *buffer);
 s32 USBStorage_OGC_StartStop(usbstorage_handle *dev, u8 lun, u8 lo_ej, u8 start, u8 imm);
 
+#define USBSTORAGE_POWER_APM_DISABLED       (1 << 0)
+#define USBSTORAGE_POWER_STANDBY_DISABLED   (1 << 1)
+#define USBSTORAGE_POWER_ALL_DISABLED       (USBSTORAGE_POWER_APM_DISABLED | USBSTORAGE_POWER_STANDBY_DISABLED)
+
+/**
+ * Disable ATA Advanced Power Management and the ATA standby timer on the
+ * currently mounted USB/SAT disk. A non-mutating ATA command is used to check
+ * pass-through support first. Returns a USBSTORAGE_POWER_* bitmask, zero when
+ * unsupported, or a negative transport error. The settings are volatile and
+ * do not write sectors or bridge firmware.
+ */
+s32 USBStorage_OGC_DisablePowerSaving();
+
 extern DISC_INTERFACE __io_usbstorage_ogc;
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Problem

Some USB hard disks enter aggressive power-saving states while a game is
idle. Their multi-second wake latency can exceed the Wii USB stack timeout
and leave a game frozen or on a black screen at its next load transition.

A similar failure was reported by another user with a Maxone 2.5-inch Wii
drive: [Game freezes at transition help](https://www.reddit.com/r/WiiHacking/comments/1rj17al/game_freezes_at_transition_help/).

## Change

Add an opt-in **Disable HDD Power Saving** option under Global Settings →
Hard Drive Settings. On the next launch, while the mounted USB disk is still
available through IOS58, the loader:

1. Sends the non-mutating ATA `CHECK POWER MODE` command to test SAT
   pass-through support.
2. Independently attempts to disable ATA Advanced Power Management.
3. Independently attempts to disable the ATA standby timer.
4. Reports full, partial, unsupported, or transport-failure results before
   continuing normal startup and reloading into cIOS.

The setting defaults to OFF. It targets only the disk already selected and
mounted by USB Loader GX. It does not write sectors, partitions, bridge
EEPROM, or firmware. The ATA settings are volatile and reset when the HDD
loses power.

Disabling power saving may keep a mechanical disk spinning continuously,
increasing power consumption, temperature, noise, and accumulated running
time. The option should therefore be enabled only when needed.

## Implementation notes

- The setting uses the existing default/load/save and Hard Drive Settings
  menu patterns.
- It is applied after the configuration is loaded but before the loader
  reloads into cIOS. At that point the selected disk is still mounted through
  the IOS58/libogc backend, which exposes the raw SCSI command path needed for
  SAT. This is why enabling the option takes effect on the next launch.
- The commands use the existing mounted device handle and LUN. There is no
  VID/PID allowlist, so the implementation is not tied to the tested Maxone
  enclosure, and the helper does not enumerate or open another USB device.
- ATA pass-through requires a 16-byte SCSI CDB. `__send_cbw()` previously
  advertised every CDB longer than six bytes as ten bytes; it now preserves
  the supplied length. Existing six- and ten-byte commands retain their
  previous advertised lengths.

## Tested hardware

- Nintendo Wii
- USB Loader GX r1283
- Maxone USB 3.0 1 TB enclosure
- JMicron JMS578 USB-to-SATA bridge (`152d:0578`, firmware `0215`)
- HGST HTS541010A9E680 1 TB 5400 RPM HDD, firmware `JA0OA560`
- FAT32 Wii game partition

The tested HDD restores ATA APM level 1 after power loss. Before disabling
power saving, an uncached read after 45 seconds idle took approximately 2.25
seconds. The same Windows test took approximately 0.06 seconds after disabling
APM and the ATA standby timer.

After a full Wii and HDD cold boot, the integrated setting successfully
prevented the previously reproducible idle/load freezes in:

- The Legend of Zelda: Twilight Princess
- Guitar Hero III

Hardware coverage is currently limited to the bridge and HDD listed above;
other SAT bridge and drive combinations have not been physically tested.

## Verification checklist

- [x] Clean build with the repository's pinned devkitPPC container
- [x] Setting defaults to OFF and persists through the existing configuration
      file
- [x] The enablement Notice explains the next-launch behavior and warns about
      increased power use, temperature, noise, and running time
- [x] Full Wii and HDD cold boot without first running the standalone utility
- [x] Previously reproducible idle/load transitions tested in two games

## Screenshots

| Setting | Enablement notice |
| --- | --- |
| ![Disable HDD Power Saving setting](https://raw.githubusercontent.com/jmbass/usbloadergx/24bab55af7174d368078a783c63e2863bd998116/pr-assets/hdd-power-saving/option.jpeg) | ![HDD power-saving warning](https://raw.githubusercontent.com/jmbass/usbloadergx/24bab55af7174d368078a783c63e2863bd998116/pr-assets/hdd-power-saving/notice.jpeg) |

## Build verification

Built successfully using the same toolchain and command as the repository
workflow:

```sh
docker run --rm \
  -v "$PWD:/project" -w /project \
  devkitpro/devkitppc:20250527 \
  sh -lc 'make clean && make release -j2'
```
