### PR TITLE
patch_sdcard: Brawl RSBE01 SD driver bypass (does not fix SD-mode black screen; reference)

### DIFF
--- a/source/patches/gamepatches.c
+++ b/source/patches/gamepatches.c
@@ -1200,6 +1200,10 @@ void patch_sdcard(u8 *gameid)
     else if (memcmp(gameid, "REXJ01", 6) == 0)
         *(u32 *)0x800ba404 = 0x4800014c;
 
+    // Super Smash Bros. Brawl (game opens /dev/sdio/slot0 at boot; skip its SD driver init so it takes the no-card path)
+    else if (memcmp(gameid, "RSBE01", 6) == 0)
+        *(u32 *)0x803ee240 = 0x38600001; // bl SDLibInit -> li r3,1  (NTSC-U v1.02)
+
     // Kirby's Return to Dream Land
     else if (memcmp(gameid, "SUKE01", 6) == 0)
     {


### PR DESCRIPTION
Adds a `patch_sdcard()` entry for Super Smash Bros. Brawl NTSC-U v1.02: replaces the SD library init call at 0x803ee240 with `li r3,1`, so `pfd_sddrv_init` returns 21 and the game takes its normal no-card path (verified in Dolphin: no `/dev/sdio/slot0` open, game runs normally).

**Draft on purpose:** on real hardware this does *not* fix Brawl's SD-Mode black screen. Issues are disabled on this repo, so the full report is below. Merge or close as you see fit; the addresses and the ruled-out cause are the useful part.

Only US v1.02 is covered; PAL/JP addresses not derived.

---

## Report
Super Smash Bros. Brawl (RSBE01, v1.02) black-screens at launch when loaded from the **front SD slot** (SD Mode) with USB Loader GX 4.0 r1283 / d2x-v11-beta3. Video resets, the Wii Remote disconnects, console stays powered. Every other game on the same card boots (10 titles incl. Skyward Sword, Galaxy 1/2, MKW, NSMBW). Brawl boots fine from the same card in a USB card reader on port 0, and from disc.

I assumed the cause was Brawl's own SD driver re-initialising `/dev/sdio/slot0` while being streamed from it, built a `patch_sdcard()` entry for it, and **it did not help** — so the failure is below the game. Posting the data in case it saves someone the same detour.

## Console
- Wii RVL-101 (Family Edition), System Menu 4.3U, Priiloader, HBC 1.1.x (OpenHBC via ModMii 8.0.6)
- cIOS: d2x-v11-beta3 in 248[38]/249[56]/250[57]/251[58]
- Loader: USB Loader GX 4.0 r1283 (wiidev enhanced e25c4f3), settings: cios 249, USBPort 0, BlockIOSReload=1, videomode=4, SD Mode
- Card: 256GB SDXC, FAT32, 32 KB clusters, MBR, front slot. Brawl as split `wbfs` + `wbf1` (7.8 GB dual layer), verified crc32.

## What Brawl does at boot (Dolphin 2606a, IOS_SD logging)
~66 ms after entry, in this order and nothing else for 100 s:
```
Opening /dev/sdio/slot0 (mode 0, fd 6)
IOCTL_GETSTATUS -> inserted+initialized
IOCTL_SENDCMD 0x40 (EVENT_REGISTER, insert/remove callback)
```
No RESETCARD, no reads. Call chain (main.dol): `pfd_sddrv_init` @0x803ee1a0 → SD lib init @0x803cc1b0 (allocs + strcpy of `/dev/sdio/slot0/1/w` into 0x80563960) → mount @0x803cc014 (`IOS_Open` @0x802123a8) → getstatus @0x803cb314 → event register @0x803cc930 ×2. Error return 21 is handled by the caller @0x803d6dfc as a normal “no card” path.

## Patch tried
`*(u32 *)0x803ee240 = 0x38600001;` for `RSBE01` in `patch_sdcard()` (replaces `bl SDLibInit` with `li r3,1`; pfd_sddrv_init logs "ERR:Failed to init SD Card Driver" and returns 21).
- Dolphin + gdb pre-boot write: **0 opens of /dev/sdio/slot0**, game runs normally.
- Same as Gecko code (`043EE240 38600001`): too late, slot0 already opened before the hook.
- As a loader build (fork CI, `make release` in devkitpro/devkitppc:20250527): **still black screen + remote disconnect on hardware, identical to unpatched.**

## Conclusion / ask
With the game never touching the SD slot, SD Mode still fails for this title only. Remaining suspects are in the cIOS/loader SD read path for a dual-layer split image (it's the only >4.7 GB / dual-layer title on the card). Happy to run any test build or capture logs; I have a reproducible setup and the gdb/Dolphin scripts.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
